### PR TITLE
Annotations implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For many of these functions, if we know additional information about the matrice
 to enable the algorithms to run faster.
 
 ```python
-Qs = cola.ops.Symmetric(Q)
+Qs = cola.Symmetric(Q)
 %timeit cola.linalg.inverse(Q)@v
 %timeit cola.linalg.inverse(Qs)@v
 ```
@@ -160,10 +160,10 @@ Linear ops
 - [ ] LUDecomposition
 - [ ] EigenDecomposition
       
-Attributes
+Annotations
 - [x] SelfAdjoint
-- [ ] PSD
-- [ ] Unitary
+- [x] PSD
+- [x] Unitary
 
 ## Contributing
 See the contributing guidelines `CONTRIBUTING.md` for information on submitting issues

--- a/cola/__init__.py
+++ b/cola/__init__.py
@@ -3,6 +3,7 @@ from cola.utils import import_from_all
 __all__ = []
 # for loader, module_name, is_pkg in  pkgutil.walk_packages(__path__):
 import_from_all("fns", globals(), __all__,__name__)
+import_from_all("annotations", globals(), __all__,__name__)
 import_from_all("linalg", globals(), __all__,__name__)
 import_from_all("utils", globals(), __all__,__name__)
 from .ops import LinearOperator

--- a/cola/annotations.py
+++ b/cola/annotations.py
@@ -1,0 +1,113 @@
+from typing import List, Union, Any, Set
+from collections.abc import Iterable
+from plum import dispatch
+from cola.ops import LinearOperator, Array
+from cola.ops import Dense
+from cola.ops import Kronecker, Product, KronSum, Sum
+from cola.ops import ScalarMul, Transpose, Adjoint
+from cola.ops import BlockDiag, Identity, Diagonal, I_like
+from cola.ops import Diagonal, Hessian, Permutation, Sliced
+from cola.utils import export
+# import reduce
+from functools import reduce
+
+Scalar = Array
+
+class WrapMeta(type):
+
+    def __str__(self):
+        return self.__name__
+    
+    def __repr__(self):
+        return self.__name__
+
+    def __call__(self, obj: LinearOperator):
+        new_obj = obj.__class__(*obj._args, **obj._kwargs)
+        new_obj.annotations = obj.annotations | {self}
+        # possible issues with pytrees and immutability?
+        return new_obj
+
+
+class Annotation(metaclass=WrapMeta):
+    pass
+
+class Stiefel(Annotation):
+    pass
+
+class Unitary(Stiefel):
+    pass
+
+class SelfAdjoint(Annotation):
+    pass
+
+Symmetric = Hermitian = SelfAdjoint
+
+class PSD(SelfAdjoint):
+    pass
+
+@dispatch
+@export
+def get_annotations(A: LinearOperator) -> Set[str]:
+    """ Return the get_annotations of a linear operator. """
+    return set()
+
+def intersect_annotations(ops: Iterable[LinearOperator]) -> Set[str]:
+    return reduce(lambda x, y: x & y, (op.annotations for op in ops))
+
+@dispatch
+def get_annotations(A: Kronecker):
+    return intersect_annotations(A.Ms)
+
+@dispatch
+def get_annotations(A: Product):
+    return intersect_annotations(A.Ms)&{Unitary,Stiefel}
+
+@dispatch
+def get_annotations(A: Sum):
+    return intersect_annotations(A.Ms)-{Unitary,Stiefel}
+
+@dispatch
+def get_annotations(A: BlockDiag):
+    return intersect_annotations(A.Ms)
+
+@dispatch
+def get_annotations(A: Diagonal):
+    if A.ops.isreal(A.diag).all(): 
+        if all(A.diag>=0):
+            return {PSD}
+        return {SelfAdjoint}
+    return set()
+
+@dispatch
+def get_annotations(A: Hessian):
+    return {SelfAdjoint}
+
+@dispatch
+def get_annotations(A: Identity):
+    return {Unitary, PSD}
+
+@dispatch
+def get_annotations(A: Permutation):
+    return {Unitary}
+
+@dispatch
+def get_annotations(A: Dense):
+    xnp = A.ops
+    sym = A.shape[0]==A.shape[-1] and xnp.allclose(A.A, xnp.conj(A.A.T))
+    return {SelfAdjoint} if sym else set()
+
+@dispatch
+def get_annotations(A: Sliced):
+    if A.slices[0]==A.slices[1]:
+        return get_annotations(A.M)-{Unitary,Stiefel}
+    # TODO: perhaps add case of slicing a unitary matrix
+    return set()
+
+@dispatch
+def get_annotations(A: Transpose):
+    #possible problem with complex
+    return A.A.annotations
+
+@dispatch
+def get_annotations(A: Adjoint):
+    return A.A.annotations

--- a/cola/fns.py
+++ b/cola/fns.py
@@ -2,14 +2,19 @@
 Like with linalg, these functions have dispatch rules and should be used in favor of the 
 LinearOperator constructors when possible. """
 
-from typing import List, Union, Any
+from typing import List, Union, Any, Set
+from collections.abc import Iterable
 from plum import dispatch
 from cola.ops import LinearOperator, Array
 from cola.ops import Dense
 from cola.ops import Kronecker, Product, KronSum, Sum
-from cola.ops import ScalarMul, Transpose, Adjoint, SelfAdjoint
+from cola.ops import ScalarMul, Transpose, Adjoint
 from cola.ops import BlockDiag, Identity, Diagonal, I_like
+from cola.ops import Diagonal
 from cola.utils import export
+from cola.annotations import SelfAdjoint
+# import reduce
+from functools import reduce
 
 Scalar = Array
 
@@ -35,11 +40,6 @@ def densify(A: Union[LinearOperator, Array]) -> Array:
 @dispatch
 def dot(A: LinearOperator, B: LinearOperator) -> Product:
     return Product(A, B)
-
-
-# @dispatch
-# def dot(A: SelfAdjoint, B: SelfAdjoint) -> SelfAdjoint:
-#     return type(A)(Product([A, B]))
 
 
 @dispatch
@@ -138,12 +138,6 @@ def kron(A: Kronecker, B: LinearOperator) -> Kronecker:
 @dispatch
 def kron(A: LinearOperator, B: Kronecker) -> Kronecker:
     return Kronecker(*((A, ) + B.Ms))
-
-
-# @dispatch
-# def kron(A: SelfAdjoint, B: SelfAdjoint) -> Kronecker:
-#     return SelfAdjoint(kron(A.A, B.A))
-# will create some problems?
 
 
 @dispatch

--- a/cola/jax_fns.py
+++ b/cola/jax_fns.py
@@ -81,6 +81,8 @@ grad = grad
 roll = jnp.roll
 maximum = jnp.maximum
 PRNGKey = PRNGKey
+isreal = jnp.isreal
+allclose = jnp.allclose
 # convolve = jax.scipy.signal.convolve
 
 

--- a/cola/linalg/sqrt.py
+++ b/cola/linalg/sqrt.py
@@ -1,6 +1,6 @@
 from plum import dispatch
 from cola.fns import lazify
-from cola.ops import SelfAdjoint
+from cola.annotations import SelfAdjoint
 from cola.ops import Diagonal
 from cola.ops import Kronecker
 from cola.ops import LinearOperator

--- a/cola/linalg/svd.py
+++ b/cola/linalg/svd.py
@@ -32,7 +32,7 @@ def svd(X: LinearOperator, rank= None, top=True, tol=1e-7, method='auto') -> Tup
     elif method == 'lanczos' or (method == 'auto' and np.prod(X.shape) > 1e6):
         Cov = X.H@X/X.shape[0]
         slc = slice(0,k) if not top else slice(-k,None)
-        eigs, V = cola.eig(cola.ops.Symmetric(Cov),slc)#,slice(0,k))
+        eigs, V = cola.eig(cola.Symmetric(Cov),slc)#,slice(0,k))
         #TODO: reverse order if other side is bigger
         U = X@V # shape (n, k)
         # singular values are the norms

--- a/cola/ops/decompositions.py
+++ b/cola/ops/decompositions.py
@@ -1,0 +1,46 @@
+from functools import reduce, partial
+from cola.ops.operator_base import LinearOperator
+import numpy as np
+from cola.utils.dispatch import parametric
+import cola
+from typing import Callable
+
+from cola.algorithms import lanczos, arnoldi
+
+from cola.utils import export
+
+@export
+class UnitaryDecomposition(LinearOperator):
+    """ Decomposition of form Q A Q^H. 
+    
+    Convenient for computing inverses, eigs, traces, determinants.
+    Assumes Q is unitary (or more precisely a Stiefel matrix): Q.H@Q = I,
+    but not necessarily Q@Q.H = I and Q need not be square.
+    """
+    def __init__(self, Q, A):
+        super().__init__(A.dtype, A.shape)
+        self.Q = cola.fns.lazify(Q)
+        self.A = cola.fns.lazify(A)
+
+
+from cola.linalg import inverse, eigs, trace, logdet, apply_unary
+
+@inverse.dispatch
+def inverse(A: UnitaryDecomposition, **kwargs):
+    Q, A = A.Q, A.A
+    return Q @ inverse(A,**kwargs) @ Q.H
+
+@eigs.dispatch
+def eigs(A: UnitaryDecomposition, **kwargs):
+    Q, A = A.Q, A.A
+    return eigs(A,**kwargs)
+
+@trace.dispatch
+def trace(A: UnitaryDecomposition, **kwargs):
+    Q, A = A.Q, A.A
+    return trace(A,**kwargs)
+
+@apply_unary.dispatch
+def apply_unary(fn: Callable, A: UnitaryDecomposition, **kwargs):
+    Q, A = A.Q, A.A
+    return Q@apply_unary(fn, A, **kwargs)@Q.H

--- a/cola/ops/operator_base.py
+++ b/cola/ops/operator_base.py
@@ -39,6 +39,8 @@ class AutoRegisteringPyTree(type):
         except ImportError:
             pass
 
+
+
 @export
 class LinearOperator(metaclass=AutoRegisteringPyTree):
     """ Linear Operator base class """
@@ -49,18 +51,26 @@ class LinearOperator(metaclass=AutoRegisteringPyTree):
         obj._kwargs = kwargs
         return obj
 
-    def __init__(self, dtype: Dtype, shape: Tuple, matmat=None):
+    def __init__(self, dtype: Dtype, shape: Tuple, matmat=None,annotations={}):
         self.dtype = dtype
         self.shape = shape
         self.ops = get_library_fns(dtype)
         if matmat is not None:
             self._matmat = matmat
+        self.annotations = cola.annotations.get_annotations(self)
+        self.annotations.update(annotations)
+        
         # self._args
         # self._kwargs
 
     def to(self, dtype=None, device=None):
         # returns a new linear operator.
         raise NotImplementedError()
+
+    def isa(self, annotation) -> bool:
+        """ Returns True if the LinearOperator has the given annotation. """
+        return any(issubclass(a,annotation) for a in self.annotations)
+
 
     @abstractmethod
     def _matmat(self, X: Array) -> Array:
@@ -111,6 +121,8 @@ class LinearOperator(metaclass=AutoRegisteringPyTree):
 
     def __rmatmul__(self, X: Array) -> Array:
         assert X.shape[-1] == self.shape[-2], f"dimension mismatch {self.shape} vs {X.shape}"
+        if self.isa(cola.annotations.SelfAdjoint):
+            return self.__matmul__(X.T).T
         if isinstance(X, LinearOperator):
             return cola.fns.dot(X, self)
         elif len(X.shape) == 1:
@@ -122,10 +134,7 @@ class LinearOperator(metaclass=AutoRegisteringPyTree):
 
     def __add__(self, other):
         # check if is numbers.Number
-        
-        if isinstance(other, Number):
-            if other == 0:
-                return self
+        if isinstance(other, Number) and other == 0: return self
         return cola.fns.add(self, other)
 
     def __radd__(self, other):
@@ -252,3 +261,14 @@ def is_array(obj):
     if get_library_fns(obj.dtype).is_array(obj):
         return True
     return False
+
+def find_device(obj, xnp):
+    if is_array(obj) or isinstance(obj, LinearOperator):
+        return obj.device
+    elif isinstance(obj, (tuple, list, set, dict)):
+        for ob in obj:
+            device = find_device(ob, xnp)
+            if device is not None:
+                return device
+    else:
+        return None

--- a/cola/ops/operators.py
+++ b/cola/ops/operators.py
@@ -50,6 +50,7 @@ class Sparse(LinearOperator):
     def __init__(self, data, indices, indptr, shape):
         super().__init__(dtype=data.dtype, shape=shape)
         self.A = self.ops.sparse_csr(indptr, indices, data)
+        
 
     def _matmat(self, V):
         return self.A @ V
@@ -279,8 +280,9 @@ class Diagonal(LinearOperator):
             >>> op = Diagonal(d)
         """
     def __init__(self, diag):
-        super().__init__(dtype=diag.dtype, shape=(len(diag), ) * 2)
         self.diag = diag
+        super().__init__(dtype=diag.dtype, shape=(len(diag), ) * 2)
+        
 
     def _matmat(self, X: Array) -> Array:
         return self.diag[:, None] * X
@@ -304,10 +306,11 @@ class Tridiagonal(LinearOperator):
         gamma (array_like): 1-D array representing upper band of the operator.
     """
     def __init__(self, alpha: Array, beta: Array, gamma: Array):
-        super().__init__(dtype=beta.dtype, shape=(beta.shape[0], beta.shape[0]))
         alpha, beta = ensure_vec_is_matrix(alpha), ensure_vec_is_matrix(beta)
         gamma = ensure_vec_is_matrix(gamma)
         self.alpha, self.beta, self.gamma = alpha, beta, gamma
+        super().__init__(dtype=beta.dtype, shape=(beta.shape[0], beta.shape[0]))
+        
 
     def _matmat(self, X: Array) -> Array:
         xnp = self.ops
@@ -336,8 +339,9 @@ def ensure_vec_is_matrix(vec):
 class Transpose(LinearOperator):
     """ Transpose of a Linear Operator"""
     def __init__(self, A):
-        super().__init__(dtype=A.dtype, shape=(A.shape[1], A.shape[0]))
         self.A = A
+        super().__init__(dtype=A.dtype, shape=(A.shape[1], A.shape[0]))
+        
 
     def _matmat(self, x):
         return self.A._rmatmat(x.T).T
@@ -353,8 +357,9 @@ class Transpose(LinearOperator):
 class Adjoint(LinearOperator):
     """ Complex conjugate transpose of a Linear Operator (aka adjoint)"""
     def __init__(self, A):
-        super().__init__(dtype=A.dtype, shape=(A.shape[1], A.shape[0]))
         self.A = A
+        super().__init__(dtype=A.dtype, shape=(A.shape[1], A.shape[0]))
+        
 
     def _matmat(self, x):
         return self.ops.conj(self.A._rmatmat(self.ops.conj(x).T)).T
@@ -373,7 +378,7 @@ class Sliced(LinearOperator):
     def __init__(self, A, slices):
         self.A = A
         self.slices = slices
-        new_shape = jnp.arange(A.shape[0])[slices[0]].shape + jnp.arange(A.shape[1])[slices[1]].shape
+        new_shape = np.arange(A.shape[0])[slices[0]].shape + np.arange(A.shape[1])[slices[1]].shape
         super().__init__(dtype=A.dtype, shape=new_shape)
 
     def _matmat(self, X: Array) -> Array:
@@ -429,36 +434,8 @@ class Jacobian(LinearOperator):
         return "J"
 
 
-@parametric
-class SelfAdjoint(LinearOperator):
-    """ SelfAdjoint property for Linearops. """
-    def __init__(self, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], LinearOperator):
-            self.A = args[0]
-            self._matmat = self.A._matmat
-            super().__init__(self.A.dtype, self.A.shape)
-        else:
-            super().__init__(*args, **kwargs)
 
-    def _rmatmat(self, X: Array) -> Array:
-        return self.ops.conj(self._matmat(self.ops.conj(X).T)).T
-
-    @property
-    def T(self):
-        return self
-
-    @property
-    def H(self):
-        return self
-
-    def __str__(self):
-        if hasattr(self, 'A'):
-            return f"S[{str(self.A)}]"
-        else:
-            return super().__str__()
-
-
-class Hessian(SelfAdjoint):
+class Hessian(LinearOperator):
     """ Hessian of a scalar function f: R^n -> R at point x.
         Matrix has shape (n, n)
 
@@ -519,6 +496,7 @@ class ConvolveND(LinearOperator):
         self.filter = filter
         self.array_shape = array_shape
         assert mode == 'same'
+        import jax.numpy as jnp
         super().__init__(dtype=filter.dtype, shape=(np.prod(array_shape), jnp.prod(array_shape)))
         self.conv = self.ops.vmap(partial(self.ops.convolve, in2=filter, mode=mode))
 
@@ -527,24 +505,7 @@ class ConvolveND(LinearOperator):
         return self.conv(Z).reshape(X.shape[-1], -1).T
 
 
-Symmetric = SelfAdjoint
-
-
-@parametric
-class PSD(SelfAdjoint):
-    """ Positive Semi-Definite property for Linearops.
-        Implies SelfAdjoint. """
-    pass
-
-
-@parametric
-class Unitary(LinearOperator):
-    def __init__(self, A: LinearOperator):
-        self.A = A
-        super().__init__(dtype=A.dtype, shape=A.shape)
-
-
-class Householder(SelfAdjoint):
+class Householder(LinearOperator):
     """ Householder rotation matrix."""
     def __init__(self, vec, beta=2.):
         super().__init__(shape=(vec.shape[-2], vec.shape[-2]), dtype=vec.dtype)

--- a/cola/test.py
+++ b/cola/test.py
@@ -1,0 +1,9 @@
+#%%
+from cola.annotations import SelfAdjoint
+from cola.ops import Dense
+import numpy as np
+A = Dense(np.random.randn(10, 10))
+print(A.annotations)
+# %%
+B = SelfAdjoint(A)
+print(B.annotations)

--- a/cola/torch_fns.py
+++ b/cola/torch_fns.py
@@ -52,7 +52,8 @@ argsort = torch.argsort
 sparse_csr = torch.sparse_csr_tensor
 roll = torch.roll
 maximum = torch.maximum
-
+isreal = torch.isreal
+allclose = torch.allclose
 from torch._vmap_internals import vmap as _vmap
 
 def PRNGKey(x):

--- a/docs/notebooks/05_Boundary_Value_PDEs.ipynb
+++ b/docs/notebooks/05_Boundary_Value_PDEs.ipynb
@@ -192,7 +192,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L = cola.ops.Symmetric(L)\n",
+    "L = cola.Symmetric(L)\n",
     "inv = cola.inverse(L,info=True,pbar=True)\n",
     "v  = inv@RHS"
    ]

--- a/docs/notebooks/06_PDE_Eigenvalue_Problems.ipynb
+++ b/docs/notebooks/06_PDE_Eigenvalue_Problems.ipynb
@@ -136,7 +136,7 @@
    ],
    "source": [
     "H = -L / 2 + V\n",
-    "energy_levels, eigenfunctions = cola.eig(cola.ops.Symmetric(H))"
+    "energy_levels, eigenfunctions = cola.eig(cola.Symmetric(H))"
    ]
   },
   {
@@ -145,7 +145,7 @@
    "id": "58ee1c48",
    "metadata": {},
    "source": [
-    "The Hamiltonian operator H is defined as the sum of the kinetic energy operator (-Δ/2) and the potential energy operator (V). The cola.ops.Symmetric function is used to inform CoLA that H is a symmetric operator which makes the eigenvalue calculation more efficient.\n",
+    "The Hamiltonian operator H is defined as the sum of the kinetic energy operator (-Δ/2) and the potential energy operator (V). The cola.Symmetric function is used to inform CoLA that H is a symmetric operator which makes the eigenvalue calculation more efficient.\n",
     "\n",
     "We then plot the lowest several eigenvalues:"
    ]

--- a/docs/notebooks/07_worksheet.ipynb
+++ b/docs/notebooks/07_worksheet.ipynb
@@ -204,7 +204,7 @@
    "metadata": {},
    "source": [
     "In the previous exercise, CoLA dispatched a general linear solver as it did not have any extra information about the `LinearOperator` that it could exploit. Lets see how to add some information about the operator such as being PSD, self-adjoint or symmetric if real.\n",
-    "In CoLA we do this using annotation operators like `cola.ops.PSD`, `cola.ops.SelfAdjoint` and `cola.ops.Symmetric`. Let's work with a PSD matrix now.\n",
+    "In CoLA we do this using annotation operators like `cola.PSD`, `cola.SelfAdjoint` and `cola.Symmetric`. Let's work with a PSD matrix now.\n",
     "Construct a `LinearOperator` $S = A A^T + \\mu I$. _Hint_: make $A$ dense, use `cola.ops.I_like` (see [docs](https://cola.readthedocs.io/en/latest/package/cola.ops.html#cola.ops.I_like)) and forget that you are using CoLA. Don't forget to annotate your operator!"
    ]
   },
@@ -406,7 +406,7 @@
     "K_train_train = cola.ops.Dense(oscale * compute_rbf_cov(train_x / ls, _))\n",
     "K_test_train = _\n",
     "K_test_test = _\n",
-    "K = cola.ops.PSD(K_train_train + noise * _)\n",
+    "K = cola.PSD(K_train_train + noise * _)\n",
     "mu = _\n",
     "Sigma = _"
    ]

--- a/docs/notebooks/colabs/05_Boundary_Value_PDEs.ipynb
+++ b/docs/notebooks/colabs/05_Boundary_Value_PDEs.ipynb
@@ -209,7 +209,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L = cola.ops.Symmetric(L)\n",
+    "L = cola.Symmetric(L)\n",
     "inv = cola.inverse(L,info=True,pbar=True)\n",
     "v  = inv@RHS"
    ]

--- a/docs/notebooks/colabs/06_PDE_Eigenvalue_Problems.ipynb
+++ b/docs/notebooks/colabs/06_PDE_Eigenvalue_Problems.ipynb
@@ -153,7 +153,7 @@
    ],
    "source": [
     "H = -L / 2 + V\n",
-    "energy_levels, eigenfunctions = cola.eig(cola.ops.Symmetric(H))"
+    "energy_levels, eigenfunctions = cola.eig(cola.Symmetric(H))"
    ]
   },
   {
@@ -162,7 +162,7 @@
    "id": "58ee1c48",
    "metadata": {},
    "source": [
-    "The Hamiltonian operator H is defined as the sum of the kinetic energy operator (-Δ/2) and the potential energy operator (V). The cola.ops.Symmetric function is used to inform CoLA that H is a symmetric operator which makes the eigenvalue calculation more efficient.\n",
+    "The Hamiltonian operator H is defined as the sum of the kinetic energy operator (-Δ/2) and the potential energy operator (V). The cola.Symmetric function is used to inform CoLA that H is a symmetric operator which makes the eigenvalue calculation more efficient.\n",
     "\n",
     "We then plot the lowest several eigenvalues:"
    ]

--- a/docs/notebooks/colabs/07_worksheet.ipynb
+++ b/docs/notebooks/colabs/07_worksheet.ipynb
@@ -221,7 +221,7 @@
    "metadata": {},
    "source": [
     "In the previous exercise, CoLA dispatched a general linear solver as it did not have any extra information about the `LinearOperator` that it could exploit. Lets see how to add some information about the operator such as being PSD, self-adjoint or symmetric if real.\n",
-    "In CoLA we do this using annotation operators like `cola.ops.PSD`, `cola.ops.SelfAdjoint` and `cola.ops.Symmetric`. Let's work with a PSD matrix now.\n",
+    "In CoLA we do this using annotation operators like `cola.PSD`, `cola.SelfAdjoint` and `cola.Symmetric`. Let's work with a PSD matrix now.\n",
     "Construct a `LinearOperator` $S = A A^T + \\mu I$. _Hint_: make $A$ dense, use `cola.ops.I_like` (see [docs](https://cola.readthedocs.io/en/latest/package/cola.ops.html#cola.ops.I_like)) and forget that you are using CoLA. Don't forget to annotate your operator!"
    ]
   },
@@ -423,7 +423,7 @@
     "K_train_train = cola.ops.Dense(oscale * compute_rbf_cov(train_x / ls, _))\n",
     "K_test_train = _\n",
     "K_test_test = _\n",
-    "K = cola.ops.PSD(K_train_train + noise * _)\n",
+    "K = cola.PSD(K_train_train + noise * _)\n",
     "mu = _\n",
     "Sigma = _"
    ]

--- a/docs/notebooks/colabs/all.ipynb
+++ b/docs/notebooks/colabs/all.ipynb
@@ -478,7 +478,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L = cola.ops.Symmetric(L)\n",
+    "L = cola.Symmetric(L)\n",
     "inv = cola.inverse(L,info=True,pbar=True)\n",
     "v  = inv@RHS"
    ]
@@ -836,7 +836,7 @@
    ],
    "source": [
     "H = -L / 2 + V\n",
-    "energy_levels, eigenfunctions = cola.eig(cola.ops.Symmetric(H))"
+    "energy_levels, eigenfunctions = cola.eig(cola.Symmetric(H))"
    ]
   },
   {
@@ -845,7 +845,7 @@
    "id": "58ee1c48",
    "metadata": {},
    "source": [
-    "The Hamiltonian operator H is defined as the sum of the kinetic energy operator (-Δ/2) and the potential energy operator (V). The cola.ops.Symmetric function is used to inform CoLA that H is a symmetric operator which makes the eigenvalue calculation more efficient.\n",
+    "The Hamiltonian operator H is defined as the sum of the kinetic energy operator (-Δ/2) and the potential energy operator (V). The cola.Symmetric function is used to inform CoLA that H is a symmetric operator which makes the eigenvalue calculation more efficient.\n",
     "\n",
     "We then plot the lowest several eigenvalues:"
    ]
@@ -1402,7 +1402,7 @@
    "metadata": {},
    "source": [
     "In the previous exercise, CoLA dispatched a general linear solver as it did not have any extra information about the `LinearOperator` that it could exploit. Lets see how to add some information about the operator such as being PSD, self-adjoint or symmetric if real.\n",
-    "In CoLA we do this using annotation operators like `cola.ops.PSD`, `cola.ops.SelfAdjoint` and `cola.ops.Symmetric`. Let's work with a PSD matrix now.\n",
+    "In CoLA we do this using annotation operators like `cola.PSD`, `cola.SelfAdjoint` and `cola.Symmetric`. Let's work with a PSD matrix now.\n",
     "Construct a `LinearOperator` $S = A A^T + \\mu I$. _Hint_: make $A$ dense, use `cola.ops.I_like` (see [docs](https://cola.readthedocs.io/en/latest/package/cola.ops.html#cola.ops.I_like)) and forget that you are using CoLA. Don't forget to annotate your operator!"
    ]
   },
@@ -1604,7 +1604,7 @@
     "K_train_train = cola.ops.Dense(oscale * compute_rbf_cov(train_x / ls, _))\n",
     "K_test_train = _\n",
     "K_test_test = _\n",
-    "K = cola.ops.PSD(K_train_train + noise * _)\n",
+    "K = cola.PSD(K_train_train + noise * _)\n",
     "mu = _\n",
     "Sigma = _"
    ]

--- a/tests/linalg/operator_market.py
+++ b/tests/linalg/operator_market.py
@@ -7,8 +7,8 @@ from cola.ops import KronSum, ScalarMul, Product, Sliced
 from cola.ops import Sparse, LowerTriangular, Kronecker, Permutation
 from cola.ops import Dense, BlockDiag, Jacobian, Hessian
 
-from cola.ops import SelfAdjoint
-from cola.ops import PSD
+from cola.annotations import SelfAdjoint
+from cola.annotations import PSD
 from cola.ops import LinearOperator
 
 xnp = jax_fns

--- a/tests/linalg/test_eig.py
+++ b/tests/linalg/test_eig.py
@@ -2,7 +2,7 @@ from cola import jax_fns
 from cola import torch_fns
 from cola.fns import lazify
 from cola.ops import Diagonal
-from cola.ops import SelfAdjoint
+from cola.annotations import SelfAdjoint
 from cola.linalg.eigs import eig
 from jax.config import config
 from cola.utils_test import parametrize, relative_error

--- a/tests/linalg/test_sqrt.py
+++ b/tests/linalg/test_sqrt.py
@@ -4,7 +4,7 @@ from cola.fns import kron
 from cola.fns import lazify
 from cola.linalg.sqrt import sqrt
 from cola.ops import Diagonal
-from cola.ops import SelfAdjoint
+from cola.annotations import SelfAdjoint
 from cola.utils_test import parametrize, relative_error
 from cola.utils_test import generate_spectrum, generate_pd_from_diag
 from jax.config import config

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -12,11 +12,10 @@ from cola.ops import Sum
 from cola.ops import ScalarMul
 from cola.ops import Product
 from cola.ops import Sliced
-from cola.ops import SelfAdjoint
-from cola.ops import Symmetric
+from cola.annotations import SelfAdjoint,PSD
+from cola.annotations import Symmetric
 from cola.ops import Householder
 from cola.ops import Sparse
-from cola.ops import PSD
 from cola.ops import LinearOperator
 from cola.algorithms.arnoldi import get_householder_vec
 from cola.utils_test import parametrize, relative_error
@@ -58,27 +57,6 @@ def test_householder(xnp):
         approx = xnp.update_array(approx, x[:idx], slice(None, idx, None))
         rel_error = relative_error(approx, R @ x)
         assert rel_error < _tol
-
-
-@parametrize([torch_fns, jax_fns])
-def test_adjoint_and_symmetric(xnp):
-    dtype = xnp.float32
-    A = [[-0.38105885, -1.13140889, -1.66344203], [1.38351046, 0.50665351, -0.29059844],
-         [0.18752258, 0.60077083, -0.95329955]]
-    Aop = SelfAdjoint(lazify(xnp.array(A, dtype=dtype)))
-    eye = I_like(Aop).to_dense()
-    rel_error = relative_error(Aop.to_dense().T, eye @ Aop)
-    assert rel_error < _tol
-
-    Aop = Symmetric(lazify(xnp.array(A, dtype=dtype)))
-    eye = I_like(Aop).to_dense()
-    rel_error = relative_error(Aop.to_dense().T, eye @ Aop)
-    assert rel_error < _tol
-
-    Aop = PSD(lazify(xnp.array(A, dtype=dtype)))
-    rel_error = relative_error(Aop.to_dense(), Aop.T.to_dense())
-    assert rel_error < _tol
-
 
 @parametrize([torch_fns, jax_fns])
 def test_unflatten(xnp):


### PR DESCRIPTION
Moving from operators for Symmetric, PSD, Unitary to annotations

`LinearOperator` base class now contains a annotations attribute (a set of Annotation classes) which is filled in during the` __init__`, which calls `cola.annotations.get_annotations` (which is dispatched on for different operators).

Can access annotations with e.g.
`
A = MyOp()
A.isa(cola.SelfAdjoint) # returns False
B = cola.PSD(A) # or cola.SelfAdjoint(A)
B.isa(cola.SelfAdjoint) # returns True
`
Uses inheritance for the annotation types
