### PR TITLE
Contributing guidelines and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,40 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+title: "[Bug]"
+labels: bug
+assignees: ''
+
+---
+
+# 🐛 Bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## To reproduce
+
+** Code snippet to reproduce **
+```python
+# Your code goes here
+# Please make sure it does not require any external dependencies (other than JaX/PyTorch!)
+# (We much prefer small snippets rather than links to existing libraries!)
+```
+
+** Stack trace/error message **
+```
+// Paste the bad output here!
+```
+
+## Expected Behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## System information
+
+**Please complete the following information:**
+- <!-- CoLA Version (run `print(cola.__version__)` -->
+- <!-- JaX and/or PyTorch Version (run `print(jax.__version__)` and/or `print(torch.__version__)` -->
+- <!-- Computer OS -->
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/---documentation-examples.md
+++ b/.github/ISSUE_TEMPLATE/---documentation-examples.md
@@ -1,0 +1,23 @@
+---
+name: "\U0001F4DA Documentation/Examples"
+about: Describe this issue template's purpose here.
+title: "[Docs]"
+labels: documentation
+assignees: ''
+
+---
+
+# 📚 Documentation/Examples
+
+** Is there documentation missing? **
+<!-- Let us know what modules have missing or incomplete documentation -->
+
+** Is documentation wrong? **
+<!-- Let us know if you find a mistake in the documentation! -->
+
+** Is there a feature that needs some example code? **
+<!-- Let us know if we're missing any example notebooks -->
+
+** Think you know how to fix the docs? ** (If so, we'd love a pull request from you!)
+
+Link to [CoLA documentation](https://cola.readthedocs.io).

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,32 @@
+---
+name: "\U0001F680 Feature request"
+about: Suggest an idea for this project
+title: "[Feature Request]"
+labels: enhancement
+assignees: ''
+
+---
+
+# 🚀 Feature Request
+
+<!-- A clear and concise description of the feature proposal -->
+
+## Motivation
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+<!-- Please link to any relevant issues or other PRs! -->
+
+## Pitch
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Are you willing to open a pull request?** (We LOVE contributions!!!)
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/---other.md
+++ b/.github/ISSUE_TEMPLATE/---other.md
@@ -1,0 +1,18 @@
+---
+name: Other
+about: Any other issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+:no_entry: **Before you submit** :no_entry:
+
+**Is this a question about using CoLA?**
+If so, please do not open an issue.
+Use the [discussions forum](https://github.com/wilson-labs/cola/discussions) instead.
+
+**Do you need help debugging personal code?**
+If so, please do not open an issue.
+Use the [discussions forum](https://github.com/wilson-labs/cola/discussions) instead.

--- a/.github/ISSUE_TEMPLATE/---refactor.md
+++ b/.github/ISSUE_TEMPLATE/---refactor.md
@@ -1,0 +1,15 @@
+---
+name: "\U0001F527 Refactor"
+about: Propose a refactor/speedup/improvement to CoLA's internals
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- A clear and concise description of what you wish to refactor. Please include the following: -->
+
+- <!-- Modules that will be modified -->
+- <!-- Impact on code structure -->
+- <!-- Impact on speed -->
+- <!-- Will this be a breaking change? -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to CoLA
+
+Thanks for contributing!
+
+## Development installation
+
+To get the development installation with all the necessary dependencies for
+linting, testing, and building the documentation, run the following:
+```bash
+git clone https://github.com/wilson-labs/cola.git
+cd cola
+pip install -e .
+pip install -r docs/requirements.txt
+```
+
+In order to properly develop for CoLA, you will need to have both [JaX](https://github.com/google/jax#installation)
+and [PyTorch](https://pytorch.org/get-started/locally/) installed.
+
+
+## Our Development Process
+
+### Docstrings
+We use [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
+If you are not familiar with this style, look around the code base for examples.
+
+
+### Unit Tests
+
+We use `pytest` to run unit tests:
+```bash
+pytest tests/
+```
+
+- To run tests within a specific directory, run (e.g.) `pytest tests/algorithms/`.
+- To run a specific unit test, run (e.g.) `pytest tests/algorithms/test_cg.py::test_cg_vjp`.
+
+
+### Documentation
+
+CoLA uses sphinx to generate documentation, and ReadTheDocs to host documentation.
+To build the documentation locally, ensure that sphinx and its plugins are properly installed (see the [development installation section](#development-installation) for instructions).
+Then run:
+
+```bash
+cd docs
+make html
+cd build/html
+python -m http.server 8000
+```
+
+The documentation will be available at http://localhost:8000.
+You will have to rerun the `make html` command every time you wish to update the docs.
+
+
+## Pull Requests
+We greatly appreciate PRs! To minimze back-and-forward communication, please ensure that your PR includes the following:
+
+1. **Code changes.** (the bug fix/new feature/updated documentation/etc.)
+1. **Unit tests.** If you are updating any code, you should add an appropraite unit test.
+   - If you are fixing a bug, make sure that there's a new unit test that catches the bug.
+     (I.e., there should be a new unit test that fails before your bug fix, but passes after your bug fix.
+     This ensures that we don't have any accidental regressions in the code base.)
+   - If you are adding a new feature, you should add unit tests for this new feature.
+1. **Documentation.** Any new objects/methods should have [appropriate docstrings](#docstrings).
+
+Before submitting a PR, ensure the following:
+1. **Unit tests pass.** See [the unit tests section](#unit-tests) for more info.
+1. **Documentation renders correctly without warnings.** [Build the documentation locally](#documentation) to ensure that your new class/docstrings are rendered correctly. Ensure that sphinx can build the documentation without warnings.
+
+
+## Issues
+
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+We accept the following types of issues:
+- Bug reports
+- Requests for documentation/examples
+- Feature requests
+- Opportuntities to refactor code
+- Performance issues (speed, memory, etc.)
+
+
+## License
+
+By contributing to CoLA, you agree that your contributions will be licensed
+under the LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
I based them off of what we have in GPyTorch, with the appropriate modifications :)

@AndPotap and @mfinzi: you should consider opening discussions for CoLA, as a forum for people to ask questions / post code examples. Ideally, this will make your issues less littered with requests for debugging help.

If you don't want to open discussions, then I'll discard the "other" issue template.