### PR TITLE
Update dependencies:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,15 @@ setup(
     license='MIT',
     python_requires='>=3.10',
     install_requires=[
-        'pytest', 'tqdm>=4.38', 'matplotlib',
+        'scipy', 'tqdm>=4.38',
         # 'plum-dispatch @ git+ssh://git@github.com/beartype/plum.git',
         # 'plum-dispatch @ git+https://github.com/beartype/plum',
         'plum-dispatch @ git+https://github.com/mfinzi/plum'\
                 '#537534597f0061ea38e499d5127e2fe78463cdfb',
     ],
+    extras_require={
+        'dev': ['pytest'],
+    },
     packages=find_packages(),
     # long_description=open('../README.md').read(),
     long_description=open('README.md').read(),


### PR DESCRIPTION
- Add scipy (which is necessary if you don't install jax)
- Remove matplotlib (it is not used in the cola/ folder)
- Make pytest an optional testing dependency

(The spicy dependency emerges when you do not install Jax; I think that torch does not require it.)
(Moreover, the `install_reqiures` should only include packages that are absolutely necessary when someone calls `import cola`, so pytest/matplotlib don't belong there.)