### PR TITLE
Ensure PyTorch cuda compatability

### DIFF
--- a/cola/algorithms/diagonal_estimation.py
+++ b/cola/algorithms/diagonal_estimation.py
@@ -15,14 +15,14 @@ def get_I_chunk_like(A: LinearOperator, i, bs, shift=0):
     elif k <= 0:
         k = abs(k)
         I_chunk = Id[:, i:i + bs + k].to_dense()
-        padded_chunk = A.xnp.zeros((A.shape[0], bs + k), dtype=A.dtype)
+        padded_chunk = A.xnp.zeros((A.shape[0], bs + k), dtype=A.dtype, device=A.device)
         slc = np.s_[:I_chunk.shape[-1]]
         padded_chunk = xnp.update_array(padded_chunk, I_chunk, slice(0, None), slc)
         chunk = I_chunk[:, :bs]
         shifted_chunk = padded_chunk[:, k:k + bs]
     else:
         I_chunk = Id[:, max(i - k, 0):i + bs].to_dense()
-        padded_chunk = A.xnp.zeros((A.shape[0], bs + k), dtype=A.dtype)
+        padded_chunk = A.xnp.zeros((A.shape[0], bs + k), dtype=A.dtype, device=A.device)
         slc = np.s_[-I_chunk.shape[-1]:]
         padded_chunk = xnp.update_array(padded_chunk, I_chunk, slice(0, None), slc)
         chunk = I_chunk[:, -bs:]
@@ -140,7 +140,7 @@ def approx_diag(A: LinearOperator, k=0, bs=100, tol=3e-2, max_iters=10000, pbar=
 
     while_loop, infos = xnp.while_loop_winfo(err, tol, pbar=pbar)
     # while_loop = xnp.while_loop
-    zeros = xnp.zeros((A.shape[0] - abs(k), ), dtype=A.dtype)
+    zeros = xnp.zeros((A.shape[0] - abs(k), ), dtype=A.dtype, device=A.device)
     n, diag_sum, *_ = while_loop(cond, body, (0, zeros, zeros, xnp.PRNGKey(42)))
     mean = diag_sum / (n * bs)
     return mean, infos

--- a/cola/algorithms/iram.py
+++ b/cola/algorithms/iram.py
@@ -15,13 +15,13 @@ def iram(A: LinearOperator, start_vector: Array = None, max_iters: int = 100, to
     del start_vector
 
     def matvec(x):
-        X = xnp.array(x, dtype=A.dtype)
+        X = xnp.array(x, dtype=A.dtype, device=A.device)
         out = A @ X
         return np.array(out, dtype=np.float32)
 
     A2 = LO(shape=A.shape, dtype=np.float32, matvec=matvec)
     k = min(A.shape[0] - 1, max_iters)
     eigvals, eigvecs = eigsh(A2, k=k, M=None, sigma=None, which="LM", v0=None, tol=tol)
-    eigvals, eigvecs = xnp.array(eigvals, dtype=A.dtype), xnp.array(eigvecs, dtype=A.dtype)
+    eigvals, eigvecs = xnp.array(eigvals, dtype=A.dtype, device=A.device), xnp.array(eigvecs, dtype=A.dtype, device=A.device)
     info = {}
     return eigvals, Dense(eigvecs), info

--- a/cola/algorithms/lobpcg.py
+++ b/cola/algorithms/lobpcg.py
@@ -14,7 +14,7 @@ def lobpcg(A: LinearOperator, start_vector: Array = None, max_iters: int = 100, 
     del pbar, start_vector, tol
 
     def matvec(x):
-        X = xnp.array(x, dtype=A.dtype)
+        X = xnp.array(x, dtype=A.dtype, device=A.device)
         out = A @ X
         return np.array(out, dtype=np.float32)
 
@@ -22,8 +22,8 @@ def lobpcg(A: LinearOperator, start_vector: Array = None, max_iters: int = 100, 
     k = min(A.shape[0] - 1, max_iters)
     X = np.random.normal(size=(A.shape[0], k)).astype(np.float32)
     eigvals, eigvecs = lobpcg_sp(A2, X)
-    eigvals = xnp.array(np.copy(eigvals), dtype=A.dtype)
-    eigvecs = xnp.array(np.copy(eigvecs), dtype=A.dtype)
+    eigvals = xnp.array(np.copy(eigvals), dtype=A.dtype, device=A.device)
+    eigvecs = xnp.array(np.copy(eigvecs), dtype=A.dtype, device=A.device)
     idx = xnp.argsort(eigvals, axis=-1)
     info = {}
     return eigvals[idx], Dense(eigvecs[:, idx]), info

--- a/cola/algorithms/preconditioners.py
+++ b/cola/algorithms/preconditioners.py
@@ -140,7 +140,7 @@ def get_nys_approx(A, Omega, eps):
     xnp = A.xnp
     Omega, _ = xnp.qr(Omega, full_matrices=False)
     Y = A @ Omega
-    # Y = xnp.array(Y, dtype=xnp.float64)
+    # Y = xnp.array(Y, dtype=xnp.float64, device=A.device)
     nu = eps * xnp.norm(Y, ord="fro")
     Y += nu * Omega
     C = xnp.cholesky(Omega.T @ Y)

--- a/cola/jax_fns.py
+++ b/cola/jax_fns.py
@@ -121,7 +121,7 @@ def lu_solve(a, b):
 
 
 def get_device(array):
-    if not isinstance(array, jax.core.Tracer):
+    if not isinstance(array, jax.core.Tracer) and hasattr(array, 'device'):
         return array.device()
     else:
         return get_default_device()

--- a/cola/linalg/diag_trace.py
+++ b/cola/linalg/diag_trace.py
@@ -58,9 +58,9 @@ def diag(A: Dense, k=0, **kwargs):
 @dispatch
 def diag(A: Identity, k=0, **kwargs):
     if k == 0:
-        return A.xnp.ones(A.shape[0], A.dtype)
+        return A.xnp.ones(A.shape[0], A.dtype, device=A.device)
     else:
-        return A.xnp.zeros(A.shape[0] - k, A.dtype)
+        return A.xnp.zeros(A.shape[0] - k, A.dtype, device=A.device)
 
 
 @dispatch
@@ -68,7 +68,7 @@ def diag(A: Diagonal, k=0, **kwargs):
     if k == 0:
         return A.diag
     else:
-        return A.xnp.zeros(A.shape[0] - k, A.dtype)
+        return A.xnp.zeros(A.shape[0] - k, A.dtype, device=A.device)
 
 
 @dispatch

--- a/cola/linalg/eigs.py
+++ b/cola/linalg/eigs.py
@@ -82,7 +82,7 @@ def eig(A: LinearOperator, **kwargs):
 # def eig(A: LowerTriangular, **kwargs):
 #     xnp = A.xnp
 #     eig_vals = diag(A.A)[eig_slice]
-#         eig_vecs = xnp.eye(eig_vals.shape[0], eig_vals.shape[0])
+#         eig_vecs = xnp.eye(eig_vals.shape[0], eig_vals.shape[0], dtype=A.dtype, device=A.device)
 #         return eig_vals, eig_vecs
 #     else:
 #         raise ValueError(f"Unknown method {method}")

--- a/cola/linalg/unary.py
+++ b/cola/linalg/unary.py
@@ -56,7 +56,7 @@ class ArnoldiUnary(LinearOperator):
         self.info.update(info)
         eigvals, P = self.xnp.eig(H)
         norms = self.xnp.norm(V, axis=0)
-        e0 = self.xnp.canonical(0, (P.shape[1], V.shape[-1]), dtype=P.dtype)
+        e0 = self.xnp.canonical(0, (P.shape[1], V.shape[-1]), dtype=P.dtype, device=self.device)
         Pinv0 = self.xnp.solve(P, e0.T)  # (bs, m, m) vs (bs, m)
         out = Pinv0 * norms[:, None]  # (bs, m)
         Q = self.xnp.cast(Q, dtype=P.dtype)  # (bs, n, m)

--- a/cola/ops/operator_base.py
+++ b/cola/ops/operator_base.py
@@ -106,7 +106,7 @@ class LinearOperator(metaclass=AutoRegisteringPyTree):
         if self.isa(cola.annotations.SelfAdjoint):
             return self.xnp.conj(self._matmat(self.xnp.conj(XT)).T)
         primals = self.xnp.zeros(shape=(self.shape[1], XT.shape[1]), dtype=XT.dtype,
-                                 device=X.device)
+                                 device=self.device)
         out = self.xnp.linear_transpose(self._matmat, primals=primals, duals=XT)
         return out.T
 


### PR DESCRIPTION
Previously, many arrays were being created without specifying the device. This omission caused device errors when using CoLA with PyTorch and cuda.

This PR adds the device kwargs to all uses of the following xnp methods:
- zeros
- ones
- array
- canonical
- eye