### PR TITLE
removing typehint outputs

### DIFF
--- a/cola/fns.py
+++ b/cola/fns.py
@@ -16,7 +16,7 @@ Scalar = Array
 
 
 @export
-def lazify(A: Union[LinearOperator, Array]) -> LinearOperator:
+def lazify(A: Union[LinearOperator, Array]):
     """ Convert an array to a linear operator if it is not already one. """
     if isinstance(A, LinearOperator):
         return A
@@ -25,7 +25,7 @@ def lazify(A: Union[LinearOperator, Array]) -> LinearOperator:
 
 
 @export
-def densify(A: Union[LinearOperator, Array]) -> Array:
+def densify(A: Union[LinearOperator, Array]):
     """ Convert a linear operator to a dense array if it is not already one. """
     if isinstance(A, LinearOperator):
         return A.to_dense()
@@ -34,22 +34,22 @@ def densify(A: Union[LinearOperator, Array]) -> Array:
 
 
 @dispatch
-def dot(A: LinearOperator, B: LinearOperator) -> Product:
+def dot(A: LinearOperator, B: LinearOperator):
     return Product(A, B)
 
 
 @dispatch
-def dot(A: Product, B: LinearOperator) -> Product:
+def dot(A: Product, B: LinearOperator):
     return Product(*(A.Ms + (B, )))
 
 
 @dispatch
-def dot(A: LinearOperator, B: Product) -> Product:
+def dot(A: LinearOperator, B: Product):
     return Product(*((A, ) + B.Ms))
 
 
 @dispatch
-def dot(A: Product, B: Product) -> Product:
+def dot(A: Product, B: Product):
     return Product(*(A.Ms + B.Ms))
 
 
@@ -64,48 +64,48 @@ def dot(A: Identity, B: Any):
 
 
 @dispatch
-def add(A: Any, B: Any) -> Sum:
+def add(A: Any, B: Any):
     return add(lazify(A), lazify(B))
 
 
 @dispatch
-def add(A: LinearOperator, B: LinearOperator) -> Sum:
+def add(A: LinearOperator, B: LinearOperator):
     return Sum(A, B)
 
 
 @dispatch
-def add(A: Sum, B: LinearOperator) -> Sum:
+def add(A: Sum, B: LinearOperator):
     return Sum(*(A.Ms + (B, )))
 
 
 @dispatch
-def add(A: LinearOperator, B: Sum) -> Sum:
+def add(A: LinearOperator, B: Sum):
     return Sum(*((A, ) + B.Ms))
 
 
 @dispatch
-def add(A: Sum, B: Sum) -> Sum:
+def add(A: Sum, B: Sum):
     return Sum(*(A.Ms + B.Ms))
 
 
 @dispatch
-def mul(A: LinearOperator, c: Scalar) -> LinearOperator:
+def mul(A: LinearOperator, c: Scalar):
     S = ScalarMul(c, (A.shape[-2], A.shape[-2]), A.dtype)
     return Product(*[S, A])
 
 
 @dispatch
-def mul(A: ScalarMul, c: Scalar) -> ScalarMul:
+def mul(A: ScalarMul, c: Scalar):
     return ScalarMul(A.c * c, A.shape, A.dtype)
 
 
 @dispatch
-def mul(c: Scalar, A: ScalarMul) -> ScalarMul:
+def mul(c: Scalar, A: ScalarMul):
     return ScalarMul(A.c * c, A.shape, A.dtype)
 
 
 @dispatch
-def mul(A: ScalarMul, B: ScalarMul) -> ScalarMul:
+def mul(A: ScalarMul, B: ScalarMul):
     return ScalarMul(A.c * B.c, A.shape, A.dtype)
 
 
@@ -152,58 +152,58 @@ def adjoint(A: Triangular):
 
 @dispatch
 @export
-def kron(A: Any, B: Any) -> Kronecker:
+def kron(A: Any, B: Any):
     """ Kronecker product of two linear operators. """
     return kron(lazify(A), lazify(B))
 
 
 @dispatch
-def kron(A: LinearOperator, B: LinearOperator) -> Kronecker:
+def kron(A: LinearOperator, B: LinearOperator):
     return Kronecker(*[A, B])
 
 
 @dispatch
-def kron(A: Diagonal, B: Diagonal) -> Diagonal:
+def kron(A: Diagonal, B: Diagonal):
     diag = (A.diag[:, None] * B.diag[None, :]).reshape(-1)
     return Diagonal(diag)
 
 
 @dispatch
-def kron(A: Kronecker, B: LinearOperator) -> Kronecker:
+def kron(A: Kronecker, B: LinearOperator):
     return Kronecker(*(A.Ms + (B, )))
 
 
 @dispatch
-def kron(A: LinearOperator, B: Kronecker) -> Kronecker:
+def kron(A: LinearOperator, B: Kronecker):
     return Kronecker(*((A, ) + B.Ms))
 
 
 @dispatch
 @export
-def kronsum(A: Any, B: Any) -> KronSum:
+def kronsum(A: Any, B: Any):
     return kronsum(lazify(A), lazify(B))
 
 
 @dispatch
-def kronsum(A: LinearOperator, B: LinearOperator) -> KronSum:
+def kronsum(A: LinearOperator, B: LinearOperator):
     return KronSum(*[A, B])
 
 
 @dispatch
-def kronsum(A: KronSum, B: LinearOperator) -> KronSum:
+def kronsum(A: KronSum, B: LinearOperator):
     return KronSum(*(A.Ms + (B, )))
 
 
 @dispatch
-def kronsum(A: LinearOperator, B: KronSum) -> KronSum:
+def kronsum(A: LinearOperator, B: KronSum):
     return KronSum(*((A, ) + B.Ms))
 
 
 @export
-def block_diag(*ops: List[LinearOperator]) -> LinearOperator:
+def block_diag(*ops: List[LinearOperator]):
     """ Construct a block diagonal operator from a list of ops. """
     return BlockDiag(*ops)
 
 
-def concatenate(ops: List[LinearOperator], axis=0) -> LinearOperator:
+def concatenate(ops: List[LinearOperator], axis=0):
     raise NotImplementedError

--- a/cola/linalg/inverse.py
+++ b/cola/linalg/inverse.py
@@ -145,7 +145,7 @@ def inverse(A: Permutation, **kwargs):
 
 
 @dispatch(cond=lambda A, **kwargs: all([M.shape[-2] == M.shape[-1] for M in A.Ms]))
-def inverse(A: Product, **kwargs) -> Product:
+def inverse(A: Product, **kwargs):
     output = reversed([inverse(M, **kwargs) for M in A.Ms])
     return Product(*output)
 

--- a/cola/linalg/logdet.py
+++ b/cola/linalg/logdet.py
@@ -15,7 +15,7 @@ def product(xs):
 
 
 @export
-def logdet(A: LinearOperator, **kwargs) -> Array:
+def logdet(A: LinearOperator, **kwargs):
     r""" Computes logdet of a linear operator. 
 
     For large inputs (or with method='iterative'),
@@ -42,7 +42,7 @@ def logdet(A: LinearOperator, **kwargs) -> Array:
 
 @dispatch
 @export
-def slogdet(A: LinearOperator, **kwargs) -> Array:
+def slogdet(A: LinearOperator, **kwargs):
     r""" Computes sign and logdet of a linear operator. such that det(A) = sign(A) exp(logdet(A))
 
     For large inputs (or with method='iterative'),
@@ -78,7 +78,7 @@ def slogdet(A: LinearOperator, **kwargs) -> Array:
 
 
 @dispatch(cond=lambda A: A.isa(PSD))
-def slogdet(A: LinearOperator, **kwargs) -> Array:
+def slogdet(A: LinearOperator, **kwargs):
     kws = dict(method="auto", tol=1e-6, vtol=1e-6, pbar=False, max_iters=300)
     # assert not kwargs.keys() - kws.keys(), f"Unknown kwargs {kwargs.keys()-kws.keys()}"
     kws.update(kwargs)
@@ -103,13 +103,13 @@ def slogdet(A: LinearOperator, **kwargs) -> Array:
 
 
 @dispatch(cond=lambda A, **kwargs: all([(Ai.shape[-2] == Ai.shape[-1]) for Ai in A.Ms]))
-def slogdet(A: Product, **kwargs) -> Array:
+def slogdet(A: Product, **kwargs):
     signs, logdets = zip(*[slogdet(Ai, **kwargs) for Ai in A.Ms])
     return product(signs), sum(logdets)
 
 
 @dispatch
-def slogdet(A: Diagonal, **kwargs) -> Array:
+def slogdet(A: Diagonal, **kwargs):
     xnp = A.xnp
     mag = xnp.abs(A.diag)
     phase = A.diag / mag
@@ -117,7 +117,7 @@ def slogdet(A: Diagonal, **kwargs) -> Array:
 
 
 @dispatch
-def slogdet(A: Kronecker, **kwargs) -> Array:
+def slogdet(A: Kronecker, **kwargs):
     # logdet(Pi A_i \otimes I) = sum_i logdet(A_i)
     signs, logdets = zip(*[slogdet(Ai, **kwargs) for Ai in A.Ms])
     sizes = [Ai.shape[-1] for Ai in A.Ms]
@@ -128,7 +128,7 @@ def slogdet(A: Kronecker, **kwargs) -> Array:
 
 
 @dispatch
-def slogdet(A: BlockDiag, **kwargs) -> Array:
+def slogdet(A: BlockDiag, **kwargs):
     # logdet(\bigoplus A_i) = log \prod det(A_i) = sum_i logdet(A_i)
     signs, logdets = zip(*[slogdet(Ai, **kwargs) for Ai in A.Ms])
     scaled_logdets = sum(ld * n for ld, n in zip(logdets, A.multiplicities))
@@ -137,7 +137,7 @@ def slogdet(A: BlockDiag, **kwargs) -> Array:
 
 
 @dispatch
-def slogdet(A: Triangular, **kwargs) -> Array:
+def slogdet(A: Triangular, **kwargs):
     xnp = A.xnp
     diag = xnp.diag(A.A)
     mag = xnp.abs(diag)
@@ -146,7 +146,7 @@ def slogdet(A: Triangular, **kwargs) -> Array:
 
 
 @dispatch
-def slogdet(A: Permutation, **kwargs) -> Array:
+def slogdet(A: Permutation, **kwargs):
     # TODO: count the parity of the permutation and return an error if it is odd
     xnp = A.xnp
     zero = xnp.array(0., dtype=A.dtype, device=A.device)


### PR DESCRIPTION
Type annotations on outputs of dispatched functions perform type conversion and this functionality is not intended for our usage. (Problems for parametric types are caused because e.g. Kronecker[A,B] doesn't match Kronecker and then plum attempts to perform a type conversion. 

@dispatch
def fn(...) -> Kronecker:

Fix: remove type outputs on dispatched functions