### PR TITLE
use pypi version of cola-plum-dispatch for dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         'scipy', 'tqdm>=4.38',
-        'cola-plum-dispatch==0.1.0',
+        'cola-plum-dispatch==0.1.1',
     ],
     extras_require={
         'dev': ['pytest', 'pytest-cov'],

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,7 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         'scipy', 'tqdm>=4.38',
-        # 'plum-dispatch @ git+ssh://git@github.com/beartype/plum.git',
-        # 'plum-dispatch @ git+https://github.com/beartype/plum',
-        'plum-dispatch @ git+https://github.com/mfinzi/plum'\
-                '#537534597f0061ea38e499d5127e2fe78463cdfb',
+        'cola-plum-dispatch==0.1.0',
     ],
     extras_require={
         'dev': ['pytest', 'pytest-cov'],


### PR DESCRIPTION
pinning to specific git hash not allowed as dependency for publishing on pypi
Instead, we needed to distribute our own version of plum-dispatch on pypi