### PR TITLE
Versioning and release automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package to PyPI and Anaconda
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  run_test_suite:
+    uses: ./.github/workflows/run_test_suite.yml
+
+  deploy_pypi:
+    runs-on: ubuntu-latest
+    needs: run_test_suite
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build setuptools setuptools_scm 
+    - name: Build package
+      run: |
+        python -m setuptools_scm
+				python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # cola
 logs/
 *.pdf
+cola/version.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,9 @@ build:
     # nodejs: "19"
     # rust: "1.64"
     # golang: "1.19"
+  jobs:
+    pre_build:
+      - python -m setuptools_scm  # Get correct version number
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/cola/__init__.py
+++ b/cola/__init__.py
@@ -1,6 +1,12 @@
-__version__ = '0.1.0'
 from cola.utils import import_from_all
 from .ops import LinearOperator
+
+# Read version number as written by setuptools_scm
+try:
+    from .version import version as __version__
+except Exception:  # pragma: no cover
+    __version__ = "Unknown"  # pragma: no cover
+
 
 __all__ = []
 # for loader, module_name, is_pkg in  pkgutil.walk_packages(__path__):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,10 @@
 # Pandoc should be installed on the OS (sudo apt install pandoc)
-sphinx
+jupyter
+matplotlib
+nbmerge
 nbsphinx
 recommonmark
-sphinx_rtd_theme
-jupyter
-nbmerge
+setuptools_scm
+sphinx
 sphinx-autodoc-typehints
-matplotlib
+sphinx_rtd_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+local_scheme = "node-and-date"
+write_to = "./cola/version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,20 @@
-from setuptools import setup, find_packages
+import io
+import os
+import re
+
+from setuptools import find_packages, setup
+
+
+# Get version from setuptools_scm file
+def find_version(*file_paths):
+    try:
+        with io.open(os.path.join(os.path.dirname(__file__), *file_paths), encoding="utf8") as fp:
+            version_file = fp.read()
+        version_match = re.search(r"^__version__ = version = ['\"]([^'\"]*)['\"]", version_file, re.M)
+        return version_match.group(1)
+    except Exception:
+        return None
+
 
 README_FILE = 'README.md'
 
@@ -6,7 +22,7 @@ project_name = "cola-ml"
 setup(
     name=project_name,
     description="",
-    version="0.0.1",
+    version=find_version("cola", "version.py"),
     author="Marc Finzi and Andres Potapczynski",
     author_email="maf820@nyu.edu",
     license='MIT',
@@ -17,7 +33,7 @@ setup(
         'optree',
     ],
     extras_require={
-        'dev': ['pytest', 'pytest-cov'],
+        'dev': ['pytest', 'pytest-cov', 'setuptools_scm'],
     },
     packages=find_packages(),
     long_description=open('README.md').read(),


### PR DESCRIPTION
## This PR

- [x] Autogenerate version numbers using [setuptools_scm](https://github.com/pypa/setuptools_scm).

This package gets the version number based on the latest `vX.X.X` tag, and appends a hash based on the distance to the tag. When we create an actual release (i.e. a new tag) the version number will read e.g. `0.0.2`. If we are in between releases, the version will read `0.1.dev333+g495f209`.

With this package in place, you don't need to update the version number in any files; just create a new tag when you plan to release.

- [x] Upload to PyPI upon release creation.


## Suggested Release Workflow
1. Click on “[releases](https://github.com/wilson-labs/cola/releases)” on the CoLA github page
2. Click the “[Draft a New Release](https://github.com/wilson-labs/cola/releases/new)” button
3. Under the “Choose a tag” dropdown, type a new tag name in the “Find or create a new tag” search box. E.g. “v0.0.2” (Target should be main)
4. You should see a button that says “generate release notes,” which should populate the release notes based on the PRs that occurred since the last release.
5. Press “publish release.” It should automatically deploy to PyPI, and all version numbers will be up-to-date.