### PR TITLE
Device and dtype not optional

### DIFF
--- a/cola/algorithms/arnoldi.py
+++ b/cola/algorithms/arnoldi.py
@@ -89,7 +89,7 @@ def arnoldi(A: LinearOperator, start_vector=None, max_iters=100, tol: float = 1e
     xnp = A.xnp
     xnp = A.xnp
     if start_vector is None:
-        start_vector = xnp.fixed_normal_samples((A.shape[-1], 1), device=A.device)
+        start_vector = xnp.fixed_normal_samples((A.shape[-1], 1), dtype=A.dtype, device=A.device)
     if use_householder:
         Q, H, infodict = run_householder_arnoldi(A=A, rhs=start_vector, max_iters=max_iters)
     else:

--- a/cola/algorithms/lanczos.py
+++ b/cola/algorithms/lanczos.py
@@ -265,7 +265,7 @@ def get_lu_from_tridiagonal(A: LinearOperator) -> Array:
         state = xnp.update_array(state, pi, i + 1)
         return state
 
-    lower, upper = xnp.array(0, dtype=xnp.int32), xnp.array(A.shape[0] - 1, dtype=xnp.int32,
-                                                            device=A.device)
+    lower = xnp.array(0, dtype=xnp.int32, device=A.device)
+    upper = xnp.array(A.shape[0] - 1, dtype=xnp.int32, device=A.device)
     eigenvals = xnp.for_loop(lower, upper, body_fun, init_val=eigenvals)
     return eigenvals

--- a/cola/algorithms/lanczos.py
+++ b/cola/algorithms/lanczos.py
@@ -111,7 +111,7 @@ def lanczos_decomp(A: LinearOperator, start_vector: Array = None, max_iters=100,
     """
     xnp = A.xnp
     if start_vector is None:
-        start_vector = xnp.fixed_normal_samples((A.shape[0], 1), device=A.device)
+        start_vector = xnp.fixed_normal_samples((A.shape[0], 1), dtype=A.dtype, device=A.device)
     alpha, beta, vec, iters, info = lanczos_parts(A=A, rhs=start_vector, max_iters=max_iters,
                                                   tol=tol, pbar=pbar)
     alpha, beta, Q = alpha[..., :iters - 1], beta[..., :iters], vec[0, :, :iters]

--- a/cola/jax_fns.py
+++ b/cola/jax_fns.py
@@ -1,26 +1,24 @@
-from jax.scipy.linalg import block_diag
-from jax.random import PRNGKey
-from jax.random import normal
-from jax import numpy as jnp
-from jax.lax import while_loop as _while_loop
-from cola.utils.control_flow import while_loop as _while_loop_no_jit
-from jax.lax import fori_loop as _for_loop
-# from cola.utils.control_flow import for_loop as _for_loop
-from jax.lax import conj as conj_lax
-from jax.lax import dynamic_slice
-# from jax.lax import dynamic_update_slice
-from jax.lax import expand_dims
+import numpy as np
+import logging
+import jax
 from jax import vjp
 from jax import jit, vmap, grad
-import jax
-from cola.utils.jax_tqdm import pbar_while, while_loop_winfo
+from jax import numpy as jnp
+from jax.random import PRNGKey
+from jax.random import normal
+from jax.lax import while_loop as _while_loop
+from jax.lax import fori_loop as _for_loop
+from jax.lax import conj as conj_lax
+from jax.lax import dynamic_slice
+from jax.lax import expand_dims
 from jax.lax.linalg import cholesky
 from jax.lax.linalg import svd
 from jax.lax.linalg import qr
+from jax.scipy.linalg import block_diag
 from jax.scipy.linalg import lu as lu_lax
 from jax.scipy.linalg import solve_triangular as solvetri
-import numpy as np
-import logging
+from cola.utils.jax_tqdm import pbar_while, while_loop_winfo
+from cola.utils.control_flow import while_loop as _while_loop_no_jit
 
 cos = jnp.cos
 sin = jnp.sin
@@ -60,7 +58,6 @@ argsort = jnp.argsort
 jit = jit
 copy = jnp.copy
 nan_to_num = jnp.nan_to_num
-# randn = np.random.randn  # a little dangerous..
 dynamic_slice = dynamic_slice
 zeros_like = jnp.zeros_like
 svd = svd
@@ -82,7 +79,6 @@ PRNGKey = PRNGKey
 isreal = jnp.isreal
 allclose = jnp.allclose
 slogdet = jnp.linalg.slogdet
-# convolve = jax.scipy.signal.convolve
 prod = jnp.prod
 moveaxis = jnp.moveaxis
 
@@ -96,7 +92,7 @@ def eig(A):
     return jax.device_put(w, device), jax.device_put(v, device)
 
 
-def eye(n, m=None, dtype=None, device=None):
+def eye(n, m, dtype, device):
     del device
     return jnp.eye(N=n, M=m, dtype=dtype)
 
@@ -166,7 +162,8 @@ def convolve(in1, in2, mode='same'):
     return out  # ,boundary='symm')
 
 
-def canonical(loc, shape, dtype, device=None):
+def canonical(loc, shape, dtype, device):
+    del device
     vec = jnp.zeros(shape=shape, dtype=dtype)
     vec = vec.at[loc].set(1.)
     return vec
@@ -184,7 +181,8 @@ def next_key(key):
     return jax.random.split(key)[0]
 
 
-def randn(*shape, dtype=None, key=None, device=None):
+def randn(*shape, dtype, device, key=None):
+    del device
     if key is None:
         print('Non keyed randn used. To be deprecated soon.')
         logging.warning('Non keyed randn used. To be deprecated soon.')
@@ -197,7 +195,8 @@ def randn(*shape, dtype=None, key=None, device=None):
         return z
 
 
-def fixed_normal_samples(shape, dtype=None, device=None):
+def fixed_normal_samples(shape, dtype, device):
+    del device
     key = PRNGKey(4)
     z = normal(key, shape, dtype=dtype)
     return z
@@ -217,17 +216,18 @@ def linear_transpose(fun, primals, duals):
     return jax.linear_transpose(fun, primals)(duals)[0]
 
 
-def zeros(shape, dtype, device=None):
+def zeros(shape, dtype, device):
     del device
     return jnp.zeros(shape=shape, dtype=dtype)
 
 
-def ones(shape, dtype, device=None):
+def ones(shape, dtype, device):
     del device
     return jnp.ones(shape=shape, dtype=dtype)
 
 
-def array(arr, dtype=None, device=None):
+def array(arr, dtype, device):
+    del device
     return jnp.array(arr, dtype=dtype)
 
 

--- a/cola/linalg/eigs.py
+++ b/cola/linalg/eigs.py
@@ -98,7 +98,7 @@ def eig(A: Triangular, eig_slice=slice(0, None, None), **kwargs):
     sorted_ind = xnp.argsort(eig_vals)
     eig_vals = eig_vals[sorted_ind]
     eig_vecs = compute_lower_triangular_eigvecs(np.array(A.A))
-    eig_vecs = xnp.array(eig_vecs, dtype=A.dtype)[:, sorted_ind]
+    eig_vecs = xnp.array(eig_vecs, dtype=A.dtype, device=A.device)[:, sorted_ind]
     return eig_vals[eig_slice], Unitary(lazify(eig_vecs[:, eig_slice]))
 
 

--- a/cola/ops/operator_base.py
+++ b/cola/ops/operator_base.py
@@ -4,7 +4,6 @@ import cola
 import numpy as np
 from cola.utils import export
 from numbers import Number
-import numpy as np
 
 Array = Dtype = Any
 export(Array)

--- a/cola/ops/operator_base.py
+++ b/cola/ops/operator_base.py
@@ -117,9 +117,9 @@ class LinearOperator(metaclass=AutoRegisteringPyTree):
     def to_dense(self) -> Array:
         """ Produces a dense array representation of the linear operator. """
         if 8 * self.shape[-2] < self.shape[-1]:
-            return self.xnp.eye(self.shape[-2], dtype=self.dtype, device=self.device) @ self
+            return self.xnp.eye(self.shape[-2], self.shape[-2], dtype=self.dtype, device=self.device) @ self
         else:
-            return self @ self.xnp.eye(self.shape[-1], dtype=self.dtype, device=self.device)
+            return self @ self.xnp.eye(self.shape[-1], self.shape[-1], dtype=self.dtype, device=self.device)
 
     @property
     def T(self):

--- a/cola/ops/operators.py
+++ b/cola/ops/operators.py
@@ -198,8 +198,8 @@ class Kronecker(LinearOperator):
 
 def kronsum(A, B):
     xnp = get_library_fns(A.dtype)
-    IA = xnp.eye(A.shape[-2], dtype=A.dtype, device=A.device)
-    IB = xnp.eye(B.shape[-2], dtype=B.dtype, device=B.device)
+    IA = xnp.eye(A.shape[-2], A.shape[-2], dtype=A.dtype, device=A.device)
+    IB = xnp.eye(B.shape[-2], B.shape[-2], dtype=B.dtype, device=B.device)
     return xnp.kron(A, IB) + xnp.kron(IA, B)
 
 

--- a/cola/torch_fns.py
+++ b/cola/torch_fns.py
@@ -1,14 +1,13 @@
 import hashlib
+import logging
 import torch
-# from torch.autograd.functional import vjp, jvp
-from cola.utils.torch_tqdm import while_loop_winfo
 from torch.nn import Parameter
-# from torch._vmap_internals import vmap as _vmap
 from torch.func import vjp, jvp
 from torch.func import vmap as _vmap
 from torch.func import grad as _grad
-import logging
+from cola.utils.torch_tqdm import while_loop_winfo
 
+Parameter = Parameter
 logdet = torch.logdet
 exp = torch.exp
 cos = torch.cos
@@ -17,7 +16,6 @@ ndarray = torch.Tensor
 arange = torch.arange
 ones_like = torch.ones_like
 sign = torch.sign
-Parameter = Parameter
 any = torch.any
 inv = torch.linalg.inv
 pinv = torch.linalg.pinv
@@ -119,7 +117,7 @@ def stop_gradients(x):
     return x.detach()
 
 
-def canonical(loc, shape, dtype, device=None):
+def canonical(loc, shape, dtype, device):
     vec = torch.zeros(shape, dtype=dtype, device=device)
     vec[loc] = 1.
     return vec
@@ -133,7 +131,7 @@ def permute(array, axes):
     return torch.permute(array, dims=axes)
 
 
-def ones(shape, dtype, device=None):
+def ones(shape, dtype, device):
     return torch.ones(size=shape, dtype=dtype, device=device)
 
 
@@ -182,7 +180,7 @@ def sha_hash(n):
     return int(hash_integer % (2**32 - 1))
 
 
-def randn(*shape, dtype=None, key=None, device=None):
+def randn(*shape, dtype, device, key=None):
     if key is None:
         print('Non keyed randn used. To be deprecated soon.')
         logging.warning('Non keyed randn used. To be deprecated soon.')
@@ -194,7 +192,7 @@ def randn(*shape, dtype=None, key=None, device=None):
     return z
 
 
-def fixed_normal_samples(shape, dtype=None, device=None):
+def fixed_normal_samples(shape, dtype, device):
     # TODO: fix random seed for sample
     return torch.randn(*shape, dtype=dtype, device=device)
 
@@ -271,11 +269,11 @@ def where(condition, x, y):
     return torch.where(condition, x, y)
 
 
-def zeros(shape, dtype, device=None):
+def zeros(shape, dtype, device):
     return torch.zeros(size=shape, dtype=dtype, device=device)
 
 
-def array(arr, dtype=None, device=None):
+def array(arr, dtype, device):
     return torch.tensor(arr, dtype=dtype, device=device)
 
 

--- a/tests/algorithms/test_cg.py
+++ b/tests/algorithms/test_cg.py
@@ -19,10 +19,10 @@ _tol = 1e-7
 def test_cg_vjp(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    diag = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype))
-    diag_soln = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype))
+    diag = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype, device=None))
+    diag_soln = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype, device=None))
     A = xnp.diag(diag)
-    ones = xnp.ones(shape=(3, 1), dtype=dtype)
+    ones = xnp.ones(shape=(3, 1), dtype=dtype, device=None)
     max_iters, tol = 5, 1e-8
     x0 = xnp.zeros_like(ones)
     pbar, tol = False, 1e-6
@@ -87,8 +87,8 @@ def test_cg_complex(backend):
     xnp = get_xnp(backend)
     dtype = xnp.complex64
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=25, dtype=np.float32)
-    A = xnp.array(generate_diagonals(diag, seed=48), dtype=dtype)
-    rhs = xnp.randn(A.shape[1], 1, dtype=dtype)
+    A = xnp.array(generate_diagonals(diag, seed=48), dtype=dtype, device=None)
+    rhs = xnp.randn(A.shape[1], 1, dtype=dtype, device=None)
     soln = xnp.solve(A, rhs)
 
     B = lazify(A)
@@ -107,8 +107,8 @@ def test_cg_random(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     diag = generate_spectrum(coeff=0.75, scale=1.0, size=25, dtype=np.float32)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype)
-    rhs = xnp.ones(shape=(A.shape[0], 5), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype, device=None)
+    rhs = xnp.ones(shape=(A.shape[0], 5), dtype=dtype, device=None)
     soln = xnp.solve(A, rhs)
 
     B = lazify(A)
@@ -129,8 +129,8 @@ def test_cg_repeated_eig(backend):
     dtype = xnp.float32
     diag = [1. for _ in range(10)] + [0.5 for _ in range(10)] + [0.25 for _ in range(10)]
     diag = np.array(diag, dtype=np.float32)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype)
-    rhs = xnp.ones(shape=(A.shape[0], 1), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype, device=None)
+    rhs = xnp.ones(shape=(A.shape[0], 1), dtype=dtype, device=None)
     soln = xnp.solve(A, rhs)
 
     B = lazify(A)
@@ -149,11 +149,11 @@ def test_cg_repeated_eig(backend):
 def test_cg_track_easy(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float64
-    A = xnp.diag(xnp.array([3., 4., 5.], dtype=dtype))
+    A = xnp.diag(xnp.array([3., 4., 5.], dtype=dtype, device=None))
     rhs = [[1, 3], [1, 4], [1, 5]]
-    rhs = xnp.array(rhs, dtype=dtype)
+    rhs = xnp.array(rhs, dtype=dtype, device=None)
     soln = [[1 / 3, 1], [1 / 4, 1], [1 / 5, 1]]
-    soln = xnp.array(soln, dtype=dtype)
+    soln = xnp.array(soln, dtype=dtype, device=None)
 
     max_iters, tolerance = 5, 1e-8
     fn = xnp.jit(run_batched_tracking_cg, static_argnums=(0, 3, 4, 5, 6))

--- a/tests/algorithms/test_gmres.py
+++ b/tests/algorithms/test_gmres.py
@@ -13,10 +13,10 @@ from cola.utils_test import generate_spectrum, generate_pd_from_diag
 def test_gmres_vjp(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    diag = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype))
-    diag_soln = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype))
+    diag = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype, device=None))
+    diag_soln = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype, device=None))
     A = xnp.diag(diag)
-    rhs = xnp.ones(shape=(3, 1), dtype=dtype)
+    rhs = xnp.ones(shape=(3, 1), dtype=dtype, device=None)
     max_iters, tol = 5, 1e-6
     use_householder, use_triangular, pbar = False, False, False
     x0, P = xnp.zeros_like(rhs), Identity(dtype=A.dtype, shape=A.shape)
@@ -58,8 +58,8 @@ def test_gmres_random(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=25, dtype=np.float32)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype)
-    rhs = xnp.ones(shape=(A.shape[0], 3), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype, device=None)
+    rhs = xnp.ones(shape=(A.shape[0], 3), dtype=dtype, device=None)
     soln = xnp.solve(A, rhs)
 
     max_iters, tol = A.shape[0] - 5, 1e-8
@@ -74,11 +74,11 @@ def test_gmres_random(backend):
 def test_gmres_easy(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    A = xnp.diag(xnp.array([3., 4., 5.], dtype=dtype))
+    A = xnp.diag(xnp.array([3., 4., 5.], dtype=dtype, device=None))
     rhs = [[1], [1], [1]]
-    rhs = xnp.array(rhs, dtype=dtype)
+    rhs = xnp.array(rhs, dtype=dtype, device=None)
     soln = [[1 / 3], [1 / 4], [1 / 5]]
-    soln = xnp.array(soln, dtype=dtype)
+    soln = xnp.array(soln, dtype=dtype, device=None)
 
     max_iters, tolerance = 3, 1e-8
     fn = gmres

--- a/tests/algorithms/test_iram.py
+++ b/tests/algorithms/test_iram.py
@@ -11,13 +11,13 @@ def test_iram_random(backend):
     dtype = xnp.float32
     np_dtype = np.float32
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=10, dtype=np_dtype)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype)
-    rhs = xnp.ones(shape=(A.shape[0], 1), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype, device=None)
+    rhs = xnp.ones(shape=(A.shape[0], 1), dtype=dtype, device=None)
 
     max_iters, tol = A.shape[0], 1e-7
     eigvals, _, _ = iram(lazify(A), start_vector=rhs, max_iters=max_iters, tol=tol)
 
-    diag = xnp.array(diag[:-1], dtype=dtype)
+    diag = xnp.array(diag[:-1], dtype=dtype, device=None)
     idx = xnp.argsort(diag, axis=-1)
     rel_error = relative_error(eigvals, diag[idx])
     assert rel_error < 5e-5

--- a/tests/algorithms/test_lobpcg.py
+++ b/tests/algorithms/test_lobpcg.py
@@ -11,12 +11,12 @@ def test_lobpcg_random(backend):
     dtype = xnp.float32
     np_dtype = np.float32
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=10, dtype=np_dtype)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype, device=None)
 
     max_iters, tol = A.shape[0], 1e-7
     eigvals, _, _ = lobpcg(lazify(A), max_iters=max_iters, tol=tol)
 
-    diag = xnp.array(diag[:-1], dtype=dtype)
+    diag = xnp.array(diag[:-1], dtype=dtype, device=None)
     idx = xnp.argsort(diag, axis=-1)
     rel_error = relative_error(eigvals, diag[idx])
     assert rel_error < 5e-5

--- a/tests/algorithms/test_stochastic_lanczos_quad.py
+++ b/tests/algorithms/test_stochastic_lanczos_quad.py
@@ -11,13 +11,13 @@ from cola.utils_test import generate_spectrum, generate_pd_from_diag
 def test_slq_vjp(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    diag = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype))
-    diag_soln = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype))
+    diag = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype, device=None))
+    diag_soln = xnp.Parameter(xnp.array([3., 4., 5.], dtype=dtype, device=None))
     _, unflatten = Diagonal(diag).flatten()
 
     def f(theta):
         A = unflatten([theta])
-        loss = stochastic_lanczos_quad(A, xnp.log, vtol=1/10, max_iters=100, tol=1e-6, pbar=False)
+        loss = stochastic_lanczos_quad(A, xnp.log, vtol=1 / 10, max_iters=100, tol=1e-6, pbar=False)
         return loss
 
     def f_alt(theta):
@@ -49,14 +49,14 @@ def test_stochastic_lanczos_quad_random(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=10, dtype=np.float32)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype, device=None)
 
     def fun(x):
         return xnp.log(x)
 
-    soln = xnp.sum(fun(xnp.array(diag, dtype=dtype)))
-    vtol, max_iters, tol = 1/np.sqrt(70), A.shape[0], 1e-7
-    approx = stochastic_lanczos_quad(lazify(A), fun, max_iters= max_iters, tol=tol,vtol=vtol)
+    soln = xnp.sum(fun(xnp.array(diag, dtype=dtype, device=None)))
+    vtol, max_iters, tol = 1 / np.sqrt(70), A.shape[0], 1e-7
+    approx = stochastic_lanczos_quad(lazify(A), fun, max_iters=max_iters, tol=tol, vtol=vtol)
 
     rel_error = relative_error(soln, approx)
     assert rel_error < 1e-1

--- a/tests/linalg/operator_market.py
+++ b/tests/linalg/operator_market.py
@@ -8,8 +8,6 @@ from cola.annotations import PSD
 from cola.utils_test import get_xnp
 from functools import reduce
 import cola
-import pytest
-
 
 op_names: set[str] = {
     'psd_big',  # skipped by default
@@ -34,7 +32,8 @@ op_names: set[str] = {
 }
 
 
-def get_test_operator(backend: str, precision: str, op_name: str, device: str = 'cpu') -> LinearOperator:
+def get_test_operator(backend: str, precision: str, op_name: str,
+                      device: str = 'cpu') -> LinearOperator:
     xnp = get_xnp(backend)
     dtype = getattr(xnp, precision)
     if backend == 'torch':
@@ -80,12 +79,12 @@ def get_test_operator(backend: str, precision: str, op_name: str, device: str = 
                     op = Tridiagonal(alpha, beta, gamma)
 
         case ('selfadj', 'hessian'):
-            f2 = lambda x: (x[1] - .1) ** 3 + xnp.cos(x[2]) + (x[0] + .2) ** 2
+            f2 = lambda x: (x[1] - .1)**3 + xnp.cos(x[2]) + (x[0] + .2)**2
             x = xnp.array([1., 2., 3.], dtype=dtype)
             op = Hessian(f2, x)
 
         case ('square', 'jacobian'):
-            f1 = lambda x: xnp.array([x[0]**2, x[1]**3, xnp.sin(x[2])],dtype=dtype)
+            f1 = lambda x: xnp.array([x[0]**2, x[1]**3, xnp.sin(x[2])], dtype=dtype)
             x = xnp.array([1, 2, 3], dtype=dtype)
             op = Jacobian(f1, x)
 

--- a/tests/linalg/test_diagonal.py
+++ b/tests/linalg/test_diagonal.py
@@ -8,7 +8,7 @@ from cola.utils_test import get_xnp, parametrize, relative_error
 @parametrize(['torch', 'jax'])
 def test_exact_diag(backend):
     xnp = get_xnp(backend)
-    A = Dense(xnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9.]], dtype=xnp.float32))
+    A = Dense(xnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9.]], dtype=xnp.float32, device=None))
     for u in [-2, -1, 0, 1, 2]:
         d1, _ = exact_diag(A, u)
         d2 = xnp.diag(A.to_dense(), u)
@@ -18,7 +18,7 @@ def test_exact_diag(backend):
 @parametrize(['torch', 'jax'])
 def test_approx_diag(backend):
     xnp = get_xnp(backend)
-    A = Dense(xnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9.]], dtype=xnp.float32))
+    A = Dense(xnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9.]], dtype=xnp.float32, device=None))
     for u in [-2, -1, 0, 1, 2]:
         d1, _ = approx_diag(A, u, tol=5e-2)
         d2 = xnp.diag(A.to_dense(), u)
@@ -28,10 +28,11 @@ def test_approx_diag(backend):
 @parametrize(['torch', 'jax'])
 def test_composite_diag(backend):
     xnp = get_xnp(backend)
-    A = Dense(xnp.array([[-1, 2], [3, 2]], dtype=xnp.float32))
+    dtype = xnp.float32
+    A = Dense(xnp.array([[-1, 2], [3, 2]], dtype=dtype, device=None))
     A = LinearOperator(A.dtype, A.shape, A._matmat)
-    B = Dense(xnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9.]], dtype=xnp.float32))
-    C = Dense(-xnp.ones((3, 3), dtype=xnp.float32))
+    B = Dense(xnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9.]], dtype=dtype, device=None))
+    C = Dense(-xnp.ones((3, 3), dtype=dtype, device=None))
     M = kron(A, B + C)
     d1 = diag(M)
     d2 = xnp.diag(M.to_dense())
@@ -41,7 +42,8 @@ def test_composite_diag(backend):
 @parametrize(['torch', 'jax'], ['exact', 'approx'])
 def test_large_trace(backend, method):
     xnp = get_xnp(backend)
-    array = xnp.fixed_normal_samples((210, 210))
+    dtype = xnp.float32
+    array = xnp.fixed_normal_samples((210, 210), dtype=dtype, device=None)
     A = Dense(array)
     A = LinearOperator(A.dtype, A.shape, A._matmat)
     d1 = trace(A, method=method, tol=2e-2)

--- a/tests/linalg/test_eig.py
+++ b/tests/linalg/test_eig.py
@@ -8,7 +8,6 @@ from cola.linalg.eigs import eig
 from cola.utils_test import get_xnp, parametrize, relative_error
 from cola.utils_test import generate_spectrum, generate_pd_from_diag
 
-
 _tol = 1e-6
 
 
@@ -17,8 +16,8 @@ def test_general(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=10)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype)
-    soln_vals = xnp.sort(xnp.array(diag, dtype=dtype))
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype, device=None)
+    soln_vals = xnp.sort(xnp.array(diag, dtype=dtype, device=None))
     A = SelfAdjoint(lazify(A))
 
     eig_vals, eig_vecs = eig(A, eig_slice=slice(0, None, None), tol=1e-6)
@@ -58,8 +57,8 @@ def test_adjoint(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=10)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype)
-    soln_vals = xnp.sort(xnp.array(diag, dtype=dtype))
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype, device=None)
+    soln_vals = xnp.sort(xnp.array(diag, dtype=dtype, device=None))
     A = SelfAdjoint(lazify(A))
     eig_vals, eig_vecs = eig(A)
     approx = eig_vecs @ xnp.diag(eig_vals) @ eig_vecs.T
@@ -86,11 +85,11 @@ def test_adjoint(backend):
 def test_triangular(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    A = xnp.array([[1., 2., 3.], [0., 6., 5.], [0., 0., 4.]], dtype=dtype)
+    A = xnp.array([[1., 2., 3.], [0., 6., 5.], [0., 0., 4.]], dtype=dtype, device=None)
     soln_vecs = compute_lower_triangular_eigvecs(np.array(A))
     A = Triangular(A)
-    soln_vals = xnp.array([1., 4., 6.], dtype=dtype)
-    soln_vecs = xnp.array(soln_vecs, dtype=dtype)[:, [0, 2, 1]]
+    soln_vals = xnp.array([1., 4., 6.], dtype=dtype, device=None)
+    soln_vecs = xnp.array(soln_vecs, dtype=dtype, device=None)[:, [0, 2, 1]]
     eig_vals, eig_vecs = eig(A)
 
     assert relative_error(soln_vals, eig_vals) < _tol
@@ -103,9 +102,9 @@ def test_identity(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     A = Identity(shape=(4, 4), dtype=dtype)
-    soln_vals = xnp.array([1., 1., 1., 1.], dtype=dtype)
+    soln_vals = xnp.array([1., 1., 1., 1.], dtype=dtype, device=None)
     eig_slice = slice(1, None, None)
-    soln_vecs = xnp.eye(4, dtype=dtype)
+    soln_vecs = xnp.eye(4, 4, dtype=dtype, device=None)
     eig_vals, eig_vecs = eig(A, eig_slice=eig_slice)
 
     assert relative_error(soln_vals[eig_slice], eig_vals) < _tol
@@ -116,9 +115,9 @@ def test_identity(backend):
 def test_diagonal(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    diag = xnp.array([0.1, 3., 0.2, 4.], dtype=dtype)
+    diag = xnp.array([0.1, 3., 0.2, 4.], dtype=dtype, device=None)
     soln_vecs = [[1., 0., 0., 0.], [0., 0., 1., 0.], [0., 1., 0., 0.], [0., 0., 0., 1.]]
-    soln_vecs = xnp.array(soln_vecs, dtype=dtype)
+    soln_vecs = xnp.array(soln_vecs, dtype=dtype, device=None)
     eig_vals, eig_vecs = eig(Diagonal(diag=diag))
     eig_vecs = eig_vecs.to_dense()
 

--- a/tests/linalg/test_inverse.py
+++ b/tests/linalg/test_inverse.py
@@ -16,7 +16,8 @@ def test_inverse(backend, precision, op_name):
     Ainv2 = inverse(A3, tol=tol, method='dense')
 
     Ainv3 = inverse(A3, tol=tol, method='iterative')
-    B = xnp.array(xnp.fixed_normal_samples((A.shape[-1], 10)), dtype=dtype)
+    B = xnp.fixed_normal_samples((A.shape[-1], 10), dtype=dtype, device=None)
+    B = xnp.array(B, dtype=dtype, device=None)
     X = Ainv @ B
     rel_error = relative_error(A @ X, B)
     assert rel_error < 3 * tol, f"Dispatch rules failed on {type(A)}"

--- a/tests/linalg/test_solve.py
+++ b/tests/linalg/test_solve.py
@@ -9,8 +9,8 @@ def test_random_linear_system(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     diag = generate_spectrum(coeff=0.75, scale=1.0, size=25)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype)
-    rhs = xnp.ones(shape=(A.shape[0], 5), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype, device=None)
+    rhs = xnp.ones(shape=(A.shape[0], 5), dtype=dtype, device=None)
     soln = xnp.solve(A, rhs)
 
     approx = cola.solve(cola.PSD(lazify(A)), rhs)

--- a/tests/linalg/test_sqrt.py
+++ b/tests/linalg/test_sqrt.py
@@ -6,7 +6,6 @@ from cola.annotations import SelfAdjoint
 from cola.utils_test import get_xnp, parametrize, relative_error
 from cola.utils_test import generate_spectrum, generate_pd_from_diag
 
-
 _tol = 1e-6
 
 
@@ -14,7 +13,7 @@ _tol = 1e-6
 def test_diagonal(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    diag = xnp.array([0.1, 0.2, 3., 4.], dtype=dtype)
+    diag = xnp.array([0.1, 0.2, 3., 4.], dtype=dtype, device=None)
     C = xnp.diag(diag**0.5)
     B = sqrt(Diagonal(diag=diag))
 
@@ -26,9 +25,9 @@ def test_diagonal(backend):
 def test_kronecker(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    diag = xnp.array([9., 4., 9., 4.], dtype=dtype)
-    diag1 = Diagonal(xnp.array([3., 3.], dtype=dtype))
-    diag2 = Diagonal(xnp.array([3., 4. / 3.], dtype=dtype))
+    diag = xnp.array([9., 4., 9., 4.], dtype=dtype, device=None)
+    diag1 = Diagonal(xnp.array([3., 3.], dtype=dtype, device=None))
+    diag2 = Diagonal(xnp.array([3., 4. / 3.], dtype=dtype, device=None))
     soln = xnp.diag(diag**0.5)
     K = kron(diag1, diag2)
     approx = sqrt(K)
@@ -42,9 +41,10 @@ def test_general(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     diag = generate_spectrum(coeff=0.75, scale=1.0, size=15)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype, device=None)
     A = SelfAdjoint(lazify(A))
-    soln = xnp.array(generate_pd_from_diag(diag ** 0.5, dtype=diag.dtype, seed=21), dtype=dtype)
+    soln = xnp.array(generate_pd_from_diag(diag**0.5, dtype=diag.dtype, seed=21), dtype=dtype,
+                     device=None)
     approx = sqrt(A).to_dense()
 
     rel_error = relative_error(soln, approx)

--- a/tests/linalg/test_unary.py
+++ b/tests/linalg/test_unary.py
@@ -14,7 +14,7 @@ def test_unary(backend, precision, op_name, fns):
     A, dtype, xnp = operator, operator.dtype, operator.xnp
     A2 = LinearOperator(A.dtype, A.shape, A._matmat)
     tol = 1e-4
-    v = xnp.randn(A.shape[-1], dtype=dtype)
+    v = xnp.randn(A.shape[-1], dtype=dtype, device=None)
     Adense = A.to_dense()
     Anp = np.array(Adense)
     fv = spfn(Anp) @ np.array(v)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -18,8 +18,8 @@ def test_inverse(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
     diag = generate_spectrum(coeff=0.75, scale=1.0, size=25)
-    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype)
-    rhs = xnp.ones(shape=(A.shape[0], 5), dtype=dtype)
+    A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype), dtype=dtype, device=None)
+    rhs = xnp.ones(shape=(A.shape[0], 5), dtype=dtype, device=None)
     soln = xnp.solve(A, rhs)
 
     approx = co.inverse(lazify(A)) @ rhs
@@ -32,9 +32,9 @@ def test_inverse(backend):
 def test_power_iteration(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    A = xnp.diag(xnp.array([10., 9.75, 3., 0.1], dtype=dtype))
+    A = xnp.diag(xnp.array([10., 9.75, 3., 0.1], dtype=dtype, device=None))
     B = lazify(A)
-    soln = xnp.array(10., dtype=dtype)
+    soln = xnp.array(10., dtype=dtype, device=None)
     tol, max_iter = 1e-7, 500
     _, approx, _ = power_iteration(B, tol=tol, max_iter=max_iter, momentum=0.)
     rel_error = relative_error(soln, approx)
@@ -48,12 +48,12 @@ def test_get_lu_from_tridiagonal(backend):
     alpha = [-1., -1., -1.]
     beta = [2., 2., 2., 1.]
     gamma = [-1., -1., -1.]
-    alpha_j = xnp.array([alpha], dtype=dtype).T
-    beta_j = xnp.array([beta], dtype=dtype).T
-    gamma_j = xnp.array([gamma], dtype=dtype).T
+    alpha_j = xnp.array([alpha], dtype=dtype, device=None).T
+    beta_j = xnp.array([beta], dtype=dtype, device=None).T
+    gamma_j = xnp.array([gamma], dtype=dtype, device=None).T
     B = Tridiagonal(alpha=alpha_j, beta=beta_j, gamma=gamma_j)
     eigenvals = xnp.jit(get_lu_from_tridiagonal, static_argnums=(0, ))(B)
-    actual = xnp.array([1 / 4, 4 / 3, 3 / 2, 2])
+    actual = xnp.array([1 / 4, 4 / 3, 3 / 2, 2], dtype=dtype, device=None)
     sorted_eigenvals = xnp.sort(eigenvals)
     rel_error = relative_error(actual, sorted_eigenvals)
     assert rel_error < _tol
@@ -68,10 +68,10 @@ def test_construct_tridiagonal(backend):
     gamma = [0.04, 0.59, 1.1]
     T = [[beta[0], gamma[0], 0, 0], [alpha[0], beta[1], gamma[1], 0],
          [0., alpha[1], beta[2], gamma[2]], [0., 0., alpha[2], beta[3]]]
-    alpha = xnp.array([alpha]).T
-    beta = xnp.array([beta]).T
-    gamma = xnp.array([gamma]).T
-    T_actual = xnp.array(T, dtype=dtype)
+    alpha = xnp.array([alpha], dtype=dtype, device=None).T
+    beta = xnp.array([beta], dtype=dtype, device=None).T
+    gamma = xnp.array([gamma], dtype=dtype, device=None).T
+    T_actual = xnp.array(T, dtype=dtype, device=None)
     fn = xnp.jit(construct_tridiagonal)
     T_soln = fn(alpha, beta, gamma)
     rel_error = relative_error(T_actual, T_soln)


### PR DESCRIPTION
Made the creation of array to not assume `device=None` as input. This is in order to ensure the correct functionality for GPU allocation.