### PR TITLE
more consistent pytrees

### DIFF
--- a/cola/np_fns.py
+++ b/cola/np_fns.py
@@ -247,7 +247,7 @@ def is_leaf(value):
 
 
 def tree_flatten(value):
-    return optree.tree_flatten(value, namespace='cola')[::-1]
+    return optree.tree_flatten(value, namespace='cola')
 
 
 def tree_unflatten(treedef, value):


### PR DESCRIPTION
- excludes pytrees that have non array leaves from the dynamic fields of pytree
(flattened LinearOperator should always be a list of arrays now, though possibly some numpy and some xnp)
- enforce consistent order of fields for a given pytree by sorting vars before tree_flatten (in case attributes get setattr called in a different order) fixing #38