### PR TITLE
Fix markdown format in GP notebook

### DIFF
--- a/docs/notebooks/03_GPs.ipynb
+++ b/docs/notebooks/03_GPs.ipynb
@@ -240,11 +240,12 @@
     "$$\n",
     "\n",
     "Here:\n",
-    "- $ y $ is the vector of target values.\n",
-    "- $ K $ is the kernel matrix computed using the RBF kernel between the training inputs.\n",
-    "- $ \\sigma^2_n $ is the noise variance.\n",
-    "- $ I $ is the identity matrix.\n",
-    "- $ n $ is the number of training examples."
+    "\n",
+    "- $y$ is the vector of target values.\n",
+    "- $K$ is the kernel matrix computed using the RBF kernel between the training inputs.\n",
+    "- $\\sigma^2_n$ is the noise variance.\n",
+    "- $I$ is the identity matrix.\n",
+    "- $n$ is the number of training examples."
    ]
   },
   {


### PR DESCRIPTION
Changes the current text:
![image](https://github.com/wilson-labs/cola/assets/3116652/4a9d1160-d92b-466c-99c7-770a7c00d119)
To this:
![image](https://github.com/wilson-labs/cola/assets/3116652/8c50e6e8-9c4a-47ca-a4c3-bd4a9128c450)
