### PR TITLE
Removing jit/vmap boundaries in iterative algorithms

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -54,7 +54,7 @@ jobs:
         if [[ ${{ matrix.jax }} == "none" ]]; then
           MARK="${MARK} and not jax";
         else
-          MARK="${MAR} and not numpy";
+          MARK="${MARK} and not numpy";
         fi
         if [[ ${{ matrix.torch }} == "none" ]]; then
           MARK="${MARK} and not torch";

--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -53,6 +53,8 @@ jobs:
         MARK="not big and not tricky"
         if [[ ${{ matrix.jax }} == "none" ]]; then
           MARK="${MARK} and not jax";
+        else
+          MARK="${MAR} and not numpy";
         fi
         if [[ ${{ matrix.torch }} == "none" ]]; then
           MARK="${MARK} and not torch";

--- a/cola/algorithms/lanczos.py
+++ b/cola/algorithms/lanczos.py
@@ -69,9 +69,9 @@ def lanczos_eigs(A: LinearOperator, start_vector: Array = None, max_iters: int =
     """
     xnp = A.xnp
     Q, T, info = lanczos(A=A, start_vector=start_vector, max_iters=max_iters, tol=tol, pbar=pbar)
-    eigvals, eigvectors = xnp.eigh(T)
+    eigvals, eigvectors = xnp.eigh(T.to_dense())
     idx = xnp.argsort(eigvals, axis=-1)
-    V = lazify(Q) @ lazify(eigvectors[:, idx])
+    V = Q @ lazify(eigvectors[:, idx])
     eigvals = eigvals[..., idx]
     return eigvals, V, info
 
@@ -162,7 +162,8 @@ def lanczos(A: LinearOperator, start_vector: Array = None, max_iters=100, tol=1e
         return Unitary(Dense(Q)), T, info
     else:
         T = xnp.vmap(Tridiagonal)(alpha, beta, alpha)
-        return xnp.vmap(Unitary(Dense(Q))), T, info
+        Q = Unitary(xnp.vmap(Dense)(Q))
+        return Q, T, info
 
 
 def initialize_lanczos_vec(xnp, rhs, max_iters, dtype):

--- a/cola/algorithms/lanczos.py
+++ b/cola/algorithms/lanczos.py
@@ -68,6 +68,8 @@ def lanczos_eigs(A: LinearOperator, start_vector: Array = None, max_iters: int =
 
     """
     xnp = A.xnp
+    if start_vector is None:
+        start_vector = xnp.randn(A.shape[0], dtype=A.dtype, device=A.device)
     Q, T, info = lanczos(A=A, start_vector=start_vector, max_iters=max_iters, tol=tol, pbar=pbar)
     eigvals, eigvectors = xnp.eigh(T.to_dense())
     idx = xnp.argsort(eigvals, axis=-1)
@@ -159,7 +161,7 @@ def lanczos(A: LinearOperator, start_vector: Array = None, max_iters=100, tol=1e
     if len(start_vector.shape) == 1:
         alpha, beta = alpha[0], beta[0]
         T = Tridiagonal(alpha, beta, alpha)
-        return Unitary(Dense(Q)), T, info
+        return Unitary(Dense(Q[0, :, :])), T, info
     else:
         T = xnp.vmap(Tridiagonal)(alpha, beta, alpha)
         Q = Unitary(xnp.vmap(Dense)(Q))

--- a/cola/algorithms/slq.py
+++ b/cola/algorithms/slq.py
@@ -1,7 +1,7 @@
 from typing import Callable
 from cola.ops import LinearOperator
-from cola.algorithms.lanczos import lanczos_parts
-from cola.algorithms.lanczos import construct_tridiagonal_batched
+from cola.algorithms.lanczos import lanczos
+# from cola.algorithms.lanczos import construct_tridiagonal
 from cola.algorithms.cg import cg
 from cola.utils import export
 from cola.utils.custom_autodiff import iterative_autograd
@@ -39,13 +39,7 @@ def slq_fwd(A, fun, num_samples, max_iters, tol, pbar, key):
     xnp = A.xnp
     _mp = xnp.finfo(A.dtype).eps
     rhs = xnp.randn(A.shape[1], num_samples, dtype=A.dtype, key=key, device=A.device)
-    alpha, beta, _, iters, _ = lanczos_parts(A, rhs, max_iters, tol, pbar)
-    if xnp.__name__.find("torch") >= 0:
-        alpha, beta = alpha[..., :iters - 1], beta[..., :iters]
-    # REMOVED by marc due to it breaking jit compilation
-    else:
-        alpha = alpha[..., :-1]
-    T = construct_tridiagonal_batched(alpha, beta, alpha)
+    _, T, _ = lanczos(A, rhs, max_iters, tol, pbar)
     eigvals, Q = xnp.eigh(T)
     tau = Q[..., 0, :]
     # approx = xnp.sum(tau**2 * fun(eigvals), axis=-1)

--- a/cola/algorithms/slq.py
+++ b/cola/algorithms/slq.py
@@ -40,6 +40,7 @@ def slq_fwd(A, fun, num_samples, max_iters, tol, pbar, key):
     _mp = xnp.finfo(A.dtype).eps
     rhs = xnp.randn(A.shape[1], num_samples, dtype=A.dtype, key=key, device=A.device)
     _, T, _ = lanczos(A, rhs, max_iters, tol, pbar)
+    T = xnp.vmap(T.__class__.to_dense)(T)
     eigvals, Q = xnp.eigh(T)
     tau = Q[..., 0, :]
     # approx = xnp.sum(tau**2 * fun(eigvals), axis=-1)

--- a/cola/backends/jax_fns.py
+++ b/cola/backends/jax_fns.py
@@ -46,7 +46,6 @@ long = jnp.int64
 reshape = jnp.reshape
 kron = jnp.kron
 moveaxis = jnp.moveaxis
-concatenate = jnp.concatenate
 block_diag = block_diag
 sqrt = jnp.sqrt
 pbar_while = pbar_while
@@ -94,10 +93,6 @@ softmax = jax.nn.softmax
 log_softmax = jax.nn.log_softmax
 promote_types = jnp.promote_types
 finfo = jnp.finfo
-
-
-def iscomplexobj(x):
-    return jnp.iscomplex(x).any()
 
 
 def iscomplexobj(x):

--- a/cola/backends/np_fns.py
+++ b/cola/backends/np_fns.py
@@ -25,7 +25,6 @@ block_diag = _block_diag
 cholesky = np.linalg.cholesky
 complex64 = np.complex64
 concat = np.concatenate
-concatenate = np.concatenate
 conj = np.conj
 copy = np.copy
 cos = np.cos

--- a/cola/backends/torch_fns.py
+++ b/cola/backends/torch_fns.py
@@ -47,7 +47,6 @@ zeros_like = torch.zeros_like
 cholesky = torch.linalg.cholesky
 min = torch.min
 while_loop_winfo = while_loop_winfo
-concat = torch.cat
 log = torch.log
 nan_to_num = torch.nan_to_num
 is_array = torch.is_tensor
@@ -282,7 +281,7 @@ def linear_transpose(fun, primals, duals):
     return vjp_derivs(fun, (primals, ), duals)[0]
 
 
-def concatenate(arrays, axis=0):
+def concat(arrays, axis=0):
     return torch.cat(arrays, dim=axis)
 
 

--- a/cola/linalg/inv.py
+++ b/cola/linalg/inv.py
@@ -9,7 +9,7 @@ from cola.ops import Kronecker, Product
 from cola.algorithms.cg import cg
 from cola.algorithms.gmres import gmres
 from cola.algorithms.svrg import solve_svrg_symmetric
-from cola.utils.dispatch import parametric
+from plum import parametric
 from cola.utils import export
 from cola.annotations import PSD, Unitary
 import cola

--- a/cola/linalg/unary.py
+++ b/cola/linalg/unary.py
@@ -7,7 +7,7 @@ import cola
 from cola.ops import LinearOperator
 from cola.utils import export
 from cola.annotations import SelfAdjoint, PSD
-from cola.utils.dispatch import parametric
+from plum import parametric
 from cola.algorithms.lanczos import lanczos_parts, construct_tridiagonal_batched
 from cola.algorithms.arnoldi import get_arnoldi_matrix
 from cola.ops import Diagonal, Identity, ScalarMul

--- a/cola/linalg/unary.py
+++ b/cola/linalg/unary.py
@@ -45,9 +45,7 @@ class LanczosUnary(LinearOperator):
 @parametric
 class ArnoldiUnary(LinearOperator):
     def __init__(self, A: LinearOperator, f: Callable, **kwargs):
-        xnp = A.xnp
         super().__init__(A.dtype, A.shape)
-        self.xnp = xnp
         self.A = A
         self.f = f
         self.kwargs = kwargs

--- a/cola/linalg/unary.py
+++ b/cola/linalg/unary.py
@@ -17,6 +17,7 @@ from cola.ops import BlockDiag, Kronecker, KronSum, I_like, Transpose, Adjoint
 def product(As):
     return reduce(lambda x, y: x @ y, As)
 
+
 @parametric
 class LanczosUnary(LinearOperator):
     def __init__(self, A: LinearOperator, f: Callable, **kwargs):
@@ -57,7 +58,7 @@ class ArnoldiUnary(LinearOperator):
         self.info.update(info)
         eigvals, P = self.xnp.eig(H)
         norms = self.xnp.norm(V, axis=0)
-        
+
         e0 = self.xnp.canonical(0, (P.shape[1], V.shape[-1]), dtype=P.dtype, device=self.device)
         Pinv0 = self.xnp.solve(P, e0.T)  # (bs, m, m) vs (bs, m)
         out = Pinv0 * norms[:, None]  # (bs, m)

--- a/cola/linalg/unary.py
+++ b/cola/linalg/unary.py
@@ -45,7 +45,9 @@ class LanczosUnary(LinearOperator):
 @parametric
 class ArnoldiUnary(LinearOperator):
     def __init__(self, A: LinearOperator, f: Callable, **kwargs):
+        xnp = A.xnp
         super().__init__(A.dtype, A.shape)
+        self.xnp = xnp
         self.A = A
         self.f = f
         self.kwargs = kwargs

--- a/cola/ops/operators.py
+++ b/cola/ops/operators.py
@@ -1,7 +1,7 @@
 from functools import reduce, partial
 from cola.ops.operator_base import LinearOperator, Array
 from cola.backends import get_library_fns
-from cola.utils.dispatch import parametric
+from plum import parametric
 import cola
 import numpy as np
 

--- a/cola/ops/operators.py
+++ b/cola/ops/operators.py
@@ -282,7 +282,7 @@ class BlockDiag(LinearOperator):
             elems = M @ v[i:i_end].T.reshape(k * multiplicity, M.shape[-1]).T
             y.append(elems.T.reshape(k, multiplicity * M.shape[0]).T)
             i = i_end
-        y = self.xnp.concatenate(y, axis=0)  # concatenate over rep axis
+        y = self.xnp.concat(y, axis=0)  # concatenate over rep axis
         return y
 
     def to_dense(self):
@@ -341,9 +341,9 @@ class Tridiagonal(LinearOperator):
         xnp = self.xnp
         output = self.beta * X
         zeros = xnp.zeros(shape=(1, X.shape[-1]), dtype=X.dtype, device=xnp.get_device(X))
-        aux_gamma = xnp.concat([self.gamma * X[1:], zeros], dim=0)
+        aux_gamma = xnp.concat([self.gamma * X[1:], zeros], axis=0)
         zeros = xnp.zeros(shape=(1, X.shape[-1]), dtype=X.dtype, device=xnp.get_device(X))
-        aux_alpha = xnp.concat([zeros, self.alpha * X[:-1]], dim=0)
+        aux_alpha = xnp.concat([zeros, self.alpha * X[:-1]], axis=0)
         return output + aux_alpha + aux_gamma
 
 
@@ -544,7 +544,7 @@ class Concatenated(LinearOperator):
         super().__init__(Ms[0].dtype, shape)
 
     def _matmat(self, V):
-        return self.xnp.concatenate([M @ V for M in self.Ms], axis=self.axis)
+        return self.xnp.concat([M @ V for M in self.Ms], axis=self.axis)
 
 
 class ConvolveND(LinearOperator):

--- a/cola/ops/operators.py
+++ b/cola/ops/operators.py
@@ -339,12 +339,11 @@ class Tridiagonal(LinearOperator):
 
     def _matmat(self, X: Array) -> Array:
         xnp = self.xnp
-        aux_alpha = xnp.zeros(shape=X.shape, dtype=X.dtype, device=xnp.get_device(X))
-        aux_gamma = xnp.zeros(shape=X.shape, dtype=X.dtype, device=xnp.get_device(X))
-
         output = self.beta * X
-        aux_gamma = xnp.update_array(aux_gamma, self.gamma * X[1:], np.s_[:-1])
-        aux_alpha = xnp.update_array(aux_alpha, self.alpha * X[:-1], np.s_[1:])
+        zeros = xnp.zeros(shape=(1, X.shape[-1]), dtype=X.dtype, device=xnp.get_device(X))
+        aux_gamma = xnp.concat([self.gamma * X[1:], zeros], dim=0)
+        zeros = xnp.zeros(shape=(1, X.shape[-1]), dtype=X.dtype, device=xnp.get_device(X))
+        aux_alpha = xnp.concat([zeros, self.alpha * X[:-1]], dim=0)
         return output + aux_alpha + aux_gamma
 
 

--- a/cola/ops/operators.py
+++ b/cola/ops/operators.py
@@ -573,8 +573,7 @@ class Householder(LinearOperator):
 
     def _matmat(self, X: Array) -> Array:
         xnp = self.xnp
-        # angle = xnp.sum(X * xnp.conj(self.vec), axis=-2, keepdims=True)
-        angle = xnp.sum(X * self.vec, axis=-2, keepdims=True)
+        angle = xnp.sum(X * xnp.conj(self.vec), axis=-2, keepdims=True)
         out = X - self.beta * angle * self.vec
         return out
 

--- a/cola/utils/__init__.py
+++ b/cola/utils/__init__.py
@@ -1,4 +1,5 @@
-from .dispatch import dispatch, parametric
+# from .dispatch import dispatch, parametric
+from plum import dispatch, parametric
 import sys
 import inspect
 import importlib

--- a/cola/utils/dispatch.py
+++ b/cola/utils/dispatch.py
@@ -1,341 +1,331 @@
-from beartype.door import TypeHint
-from beartype.roar import BeartypeDoorNonpepException
+# from beartype.door import TypeHint
+# from beartype.roar import BeartypeDoorNonpepException
 
-from plum.dispatcher import Dispatcher
-from plum.function import _owner_transfer
-from plum.type import resolve_type_hint
-from plum.util import repr_short
+# from plum.dispatcher import Dispatcher
+# from plum.function import _owner_transfer
+# from plum.type import resolve_type_hint
+# from plum.util import repr_short
 
-dispatch = Dispatcher()
+# dispatch = Dispatcher()
 
+# class ParametricTypeMeta(type):
+#     """Parametric types can be instantiated with indexing.
+#     A concrete parametric type can be instantiated by calling `Type[Par1, Par2]`.
+#     If `Type(Arg1, Arg2, **kw_args)` is called, this returns
+#     `Type[type(Arg1), type(Arg2)](Arg1, Arg2, **kw_args)`.
+#     """
+#     def __getitem__(cls, p):
+#         if not cls.concrete:
+#             # Initialise the type parameters. This can perform, e.g., validation.
+#             p = p if isinstance(p, tuple) else (p, )  # Ensure that it is a tuple.
+#             p = cls.__init_type_parameter__(*p)
+#             # Type parameter has been initialised! Proceed to construct the type.
+#             p = p if isinstance(p, tuple) else (p, )  # Again ensure that it is a tuple.
+#             return cls.__new__(cls, *p)
+#         else:
+#             raise TypeError("Cannot specify type parameters. This type is concrete.")
 
-class ParametricTypeMeta(type):
-    """Parametric types can be instantiated with indexing.
-    A concrete parametric type can be instantiated by calling `Type[Par1, Par2]`.
-    If `Type(Arg1, Arg2, **kw_args)` is called, this returns
-    `Type[type(Arg1), type(Arg2)](Arg1, Arg2, **kw_args)`.
-    """
-    def __getitem__(cls, p):
-        if not cls.concrete:
-            # Initialise the type parameters. This can perform, e.g., validation.
-            p = p if isinstance(p, tuple) else (p, )  # Ensure that it is a tuple.
-            p = cls.__init_type_parameter__(*p)
-            # Type parameter has been initialised! Proceed to construct the type.
-            p = p if isinstance(p, tuple) else (p, )  # Again ensure that it is a tuple.
-            return cls.__new__(cls, *p)
-        else:
-            raise TypeError("Cannot specify type parameters. This type is concrete.")
+#     def __concrete_class__(cls, *args, **kw_args):
+#         """If `cls` is not a concrete class, infer the type parameters and return a
+#         concrete class. If `cls` is already a concrete class, simply return it.
+#         Args:
+#             *args: Positional arguments passed to the `__init__` method.
+#             **kw_args: Keyword arguments passed to the `__init__` method.
+#         Returns:
+#             type: A concrete class.
+#         """
+#         if getattr(cls, "parametric", False):
+#             if not cls.concrete:
+#                 type_parameter = cls.__infer_type_parameter__(*args, **kw_args)
+#                 cls = cls[type_parameter]
+#         return cls
 
-    def __concrete_class__(cls, *args, **kw_args):
-        """If `cls` is not a concrete class, infer the type parameters and return a
-        concrete class. If `cls` is already a concrete class, simply return it.
-        Args:
-            *args: Positional arguments passed to the `__init__` method.
-            **kw_args: Keyword arguments passed to the `__init__` method.
-        Returns:
-            type: A concrete class.
-        """
-        if getattr(cls, "parametric", False):
-            if not cls.concrete:
-                type_parameter = cls.__infer_type_parameter__(*args, **kw_args)
-                cls = cls[type_parameter]
-        return cls
+#     def __init_type_parameter__(cls, *ps):
+#         """Function called to initialise the type parameters.
+#         The default behaviour is to just return `ps`.
+#         Args:
+#             *ps (object): Type parameters.
+#         Returns:
+#             object: Initialised type parameters.
+#         """
+#         return ps
 
-    def __init_type_parameter__(cls, *ps):
-        """Function called to initialise the type parameters.
-        The default behaviour is to just return `ps`.
-        Args:
-            *ps (object): Type parameters.
-        Returns:
-            object: Initialised type parameters.
-        """
-        return ps
+#     def __infer_type_parameter__(cls, *args, **kw_args):
+#         """Function called when the constructor of this parametric type is called
+#         before the parameters have been specified.
+#         The default behaviour is to take as parameters the type of every argument,
+#         but this behaviour can be overridden by redefining this function on the
+#         metaclass.
+#         Args:
+#             *args: Positional arguments passed to the `__init__` method.
+#             **kw_args: Keyword arguments passed to the `__init__` method.
+#         Returns:
+#             type or tuple[type]: A type or tuple of types.
+#         """
+#         type_parameter = tuple(type(arg) for arg in args)
+#         if len(type_parameter) == 1:
+#             type_parameter = type_parameter[0]
+#         return type_parameter
 
-    def __infer_type_parameter__(cls, *args, **kw_args):
-        """Function called when the constructor of this parametric type is called
-        before the parameters have been specified.
-        The default behaviour is to take as parameters the type of every argument,
-        but this behaviour can be overridden by redefining this function on the
-        metaclass.
-        Args:
-            *args: Positional arguments passed to the `__init__` method.
-            **kw_args: Keyword arguments passed to the `__init__` method.
-        Returns:
-            type or tuple[type]: A type or tuple of types.
-        """
-        type_parameter = tuple(type(arg) for arg in args)
-        if len(type_parameter) == 1:
-            type_parameter = type_parameter[0]
-        return type_parameter
+#     @property
+#     def parametric(cls):
+#         """bool: Check whether the type is a parametric type."""
+#         return getattr(cls, "_parametric", False)
 
-    @property
-    def parametric(cls):
-        """bool: Check whether the type is a parametric type."""
-        return getattr(cls, "_parametric", False)
+#     @property
+#     def concrete(cls):
+#         """bool: Check whether the parametric type is instantiated or not."""
+#         if cls.parametric:
+#             return getattr(cls, "_concrete", False)
+#         else:
+#             raise RuntimeError("Cannot check whether a non-parametric type is instantiated or not.")
 
-    @property
-    def concrete(cls):
-        """bool: Check whether the parametric type is instantiated or not."""
-        if cls.parametric:
-            return getattr(cls, "_concrete", False)
-        else:
-            raise RuntimeError("Cannot check whether a non-parametric type is instantiated or not.")
+#     @property
+#     def type_parameter(cls):
+#         """object: Get the type parameter. Parametric type must be instantiated."""
+#         if cls.concrete:
+#             return cls._type_parameter
+#         else:
+#             raise RuntimeError("Cannot get the type parameter of non-instantiated parametric type.")
 
-    @property
-    def type_parameter(cls):
-        """object: Get the type parameter. Parametric type must be instantiated."""
-        if cls.concrete:
-            return cls._type_parameter
-        else:
-            raise RuntimeError("Cannot get the type parameter of non-instantiated parametric type.")
+# def _default_le_type_par(p_left, p_right):
+#     if is_type(p_left) and is_type(p_right):
+#         p_left = TypeHint(resolve_type_hint(p_left))
+#         p_right = TypeHint(resolve_type_hint(p_right))
+#         return p_left <= p_right
+#     else:
+#         return p_left == p_right
 
+# class CovariantMeta(ParametricTypeMeta):
+#     """A metaclass that implements *covariance* of parametric types."""
+#     def __subclasscheck__(cls, subclass):
+#         if is_concrete(cls) and is_concrete(subclass):
+#             # Check that they are instances of the same parametric type.
+#             if all(issubclass(b, cls.__bases__) for b in subclass.__bases__):
+#                 p_sub = subclass.type_parameter
+#                 p_cls = cls.type_parameter
+#                 # Ensure that both are in tuple form.
+#                 p_sub = p_sub if isinstance(p_sub, tuple) else (p_sub, )
+#                 p_cls = p_cls if isinstance(p_cls, tuple) else (p_cls, )
+#                 return cls.__le_type_parameter__(p_sub, p_cls)
 
-def _default_le_type_par(p_left, p_right):
-    if is_type(p_left) and is_type(p_right):
-        p_left = TypeHint(resolve_type_hint(p_left))
-        p_right = TypeHint(resolve_type_hint(p_right))
-        return p_left <= p_right
-    else:
-        return p_left == p_right
+#         # Default behaviour to `type`s subclass check.
+#         return type.__subclasscheck__(cls, subclass)
 
+#     def __le_type_parameter__(cls, p_left, p_right):
+#         # Check that there are an equal number of parameters.
+#         if len(p_left) != len(p_right):
+#             return False
+#         # Check every pair of parameters.
+#         return all(_default_le_type_par(p1, p2) for p1, p2 in zip(p_left, p_right))
 
-class CovariantMeta(ParametricTypeMeta):
-    """A metaclass that implements *covariance* of parametric types."""
-    def __subclasscheck__(cls, subclass):
-        if is_concrete(cls) and is_concrete(subclass):
-            # Check that they are instances of the same parametric type.
-            if all(issubclass(b, cls.__bases__) for b in subclass.__bases__):
-                p_sub = subclass.type_parameter
-                p_cls = cls.type_parameter
-                # Ensure that both are in tuple form.
-                p_sub = p_sub if isinstance(p_sub, tuple) else (p_sub, )
-                p_cls = p_cls if isinstance(p_cls, tuple) else (p_cls, )
-                return cls.__le_type_parameter__(p_sub, p_cls)
+# def parametric(original_class=None):
+#     """A decorator for parametric classes.
+#     When the constructor of this parametric type is called before the type parameter
+#     has been specified, the type parameter is inferred from the arguments of the
+#     constructor by calling `__inter_type_parameter__`. The default implementation is
+#     shown here, but it is possible to override it::
+#         @classmethod
+#         def __infer_type_parameter__(cls, *args, **kw_args) -> tuple:
+#             return tuple(type(arg) for arg in args)
+#     After the type parameter is given or inferred, `__init_type_parameter__` is called.
+#     Again, the default implementation is show here, but it is possible to override it::
+#         @classmethod
+#         def __init_type_parameter__(cls, *ps) -> tuple:
+#             return ps
+#     To determine which one instance of a parametric class is a subclass of another,
+#     the type parameters are compared with `__le_type_parameter__`::
+#         @classmethod
+#         def __le_type_parameter__(cls, left, right) -> bool:
+#             ...  # Is `left <= right`?
+#     """
 
-        # Default behaviour to `type`s subclass check.
-        return type.__subclasscheck__(cls, subclass)
+#     original_meta = type(original_class)
 
-    def __le_type_parameter__(cls, p_left, p_right):
-        # Check that there are an equal number of parameters.
-        if len(p_left) != len(p_right):
-            return False
-        # Check every pair of parameters.
-        return all(_default_le_type_par(p1, p2) for p1, p2 in zip(p_left, p_right))
+#     # Make a metaclass that derives from both the metaclass of `original_meta` and
+#     # `CovariantMeta`, but make sure not to insert `CovariantMeta` twice, because that
+#     # will error.
 
+#     if CovariantMeta in original_meta.__mro__:
+#         bases = (original_meta, )
+#         name = original_meta.__name__
+#     else:
+#         bases = (CovariantMeta, original_meta)
+#         name = f"CovariantMeta[{repr_short(original_meta)}]"
 
-def parametric(original_class=None):
-    """A decorator for parametric classes.
-    When the constructor of this parametric type is called before the type parameter
-    has been specified, the type parameter is inferred from the arguments of the
-    constructor by calling `__inter_type_parameter__`. The default implementation is
-    shown here, but it is possible to override it::
-        @classmethod
-        def __infer_type_parameter__(cls, *args, **kw_args) -> tuple:
-            return tuple(type(arg) for arg in args)
-    After the type parameter is given or inferred, `__init_type_parameter__` is called.
-    Again, the default implementation is show here, but it is possible to override it::
-        @classmethod
-        def __init_type_parameter__(cls, *ps) -> tuple:
-            return ps
-    To determine which one instance of a parametric class is a subclass of another,
-    the type parameters are compared with `__le_type_parameter__`::
-        @classmethod
-        def __le_type_parameter__(cls, left, right) -> bool:
-            ...  # Is `left <= right`?
-    """
+#     def __call__(cls, *args, **kw_args):
+#         cls = cls.__concrete_class__(*args, **kw_args)
+#         return original_meta.__call__(cls, *args, **kw_args)
 
-    original_meta = type(original_class)
+#     meta = type(name, bases, {"__call__": __call__})
 
-    # Make a metaclass that derives from both the metaclass of `original_meta` and
-    # `CovariantMeta`, but make sure not to insert `CovariantMeta` twice, because that
-    # will error.
+#     subclasses = {}
 
-    if CovariantMeta in original_meta.__mro__:
-        bases = (original_meta, )
-        name = original_meta.__name__
-    else:
-        bases = (CovariantMeta, original_meta)
-        name = f"CovariantMeta[{repr_short(original_meta)}]"
+#     def __new__(cls, *ps):
+#         # Only create a new subclass if it doesn't exist already.
+#         if ps not in subclasses:
 
-    def __call__(cls, *args, **kw_args):
-        cls = cls.__concrete_class__(*args, **kw_args)
-        return original_meta.__call__(cls, *args, **kw_args)
+#             if original_class.__new__ is not object.__new__:
 
-    meta = type(name, bases, {"__call__": __call__})
+#                 def __new__(cls, *args, **kw_args):
+#                     return original_class.__new__(cls, *args, **kw_args)
+#             else:
+#                 __new__ = original_class.__new__
 
-    subclasses = {}
+#             # Create subclass.
+#             name = original_class.__name__
+#             name += "[" + ", ".join(repr_short(p) for p in ps) + "]"
+#             subclass = meta(
+#                 name,
+#                 (parametric_class, ),
+#                 {"__new__": __new__},
+#             )
+#             subclass._parametric = True
+#             subclass._concrete = True
+#             subclass._type_parameter = ps[0] if len(ps) == 1 else ps
+#             subclass.__module__ = original_class.__module__
 
-    def __new__(cls, *ps):
-        # Only create a new subclass if it doesn't exist already.
-        if ps not in subclasses:
+#             # Attempt to correct docstring.
+#             try:
+#                 subclass.__doc__ = original_class.__doc__
+#             except AttributeError:  # pragma: no cover
+#                 pass
 
-            if original_class.__new__ is not object.__new__:
+#             subclasses[ps] = subclass
+#         return subclasses[ps]
 
-                def __new__(cls, *args, **kw_args):
-                    return original_class.__new__(cls, *args, **kw_args)
-            else:
-                __new__ = original_class.__new__
+#     def __init_subclass__(cls, **kw_args):
+#         cls._parametric = False
+#         # If the subclass has the same `__new__` as `ParametricClass`, then we should
+#         # replace it with the `__new__` of `Class`. If the user already defined another
+#         # `__new__`, then everything is fine.
+#         if cls.__new__ is __new__:
 
-            # Create subclass.
-            name = original_class.__name__
-            name += "[" + ", ".join(repr_short(p) for p in ps) + "]"
-            subclass = meta(
-                name,
-                (parametric_class, ),
-                {"__new__": __new__},
-            )
-            subclass._parametric = True
-            subclass._concrete = True
-            subclass._type_parameter = ps[0] if len(ps) == 1 else ps
-            subclass.__module__ = original_class.__module__
+#             def class_new(cls, *args, **kw_args):
+#                 return original_class.__new__(cls)
 
-            # Attempt to correct docstring.
-            try:
-                subclass.__doc__ = original_class.__doc__
-            except AttributeError:  # pragma: no cover
-                pass
+#             cls.__new__ = class_new
+#         original_class.__init_subclass__(**kw_args)
 
-            subclasses[ps] = subclass
-        return subclasses[ps]
+#     # Create parametric class.
+#     parametric_class = meta(
+#         original_class.__name__,
+#         (original_class, ),
+#         {
+#             "__new__": __new__,
+#             "__init_subclass__": __init_subclass__
+#         },
+#     )
+#     parametric_class._parametric = True
+#     parametric_class._concrete = False
+#     parametric_class.__module__ = original_class.__module__
 
-    def __init_subclass__(cls, **kw_args):
-        cls._parametric = False
-        # If the subclass has the same `__new__` as `ParametricClass`, then we should
-        # replace it with the `__new__` of `Class`. If the user already defined another
-        # `__new__`, then everything is fine.
-        if cls.__new__ is __new__:
+#     # When dispatch is used in methods of `original_class`, because we return
+#     # `parametric_class`, `parametric_class` will be inferred as the owner of those
+#     # functions. This is erroneous, because the owner should be `original_class`. What
+#     # will happen is that `original_class` will be the next in the MRO, which means
+#     # that, whenever a `NotFoundLookupError` happens, the method will try itself again,
+#     # resulting in an infinite loop. To prevent this from happening, we must adjust the
+#     # owner.
+#     _owner_transfer[parametric_class] = original_class
 
-            def class_new(cls, *args, **kw_args):
-                return original_class.__new__(cls)
+#     # Attempt to correct docstring.
+#     try:
+#         parametric_class.__doc__ = original_class.__doc__
+#     except AttributeError:  # pragma: no cover
+#         pass
 
-            cls.__new__ = class_new
-        original_class.__init_subclass__(**kw_args)
+#     return parametric_class
 
-    # Create parametric class.
-    parametric_class = meta(
-        original_class.__name__,
-        (original_class, ),
-        {
-            "__new__": __new__,
-            "__init_subclass__": __init_subclass__
-        },
-    )
-    parametric_class._parametric = True
-    parametric_class._concrete = False
-    parametric_class.__module__ = original_class.__module__
+# def is_concrete(t):
+#     """Check if a type `t` is a concrete instance of a parametric type.
+#     Args:
+#         t (type): Type to check.
+#     Returns:
+#         bool: `True` if `t` is a concrete instance of a parametric type and `False`
+#             otherwise.
+#     """
+#     return getattr(t, "parametric", False) and t.concrete
 
-    # When dispatch is used in methods of `original_class`, because we return
-    # `parametric_class`, `parametric_class` will be inferred as the owner of those
-    # functions. This is erroneous, because the owner should be `original_class`. What
-    # will happen is that `original_class` will be the next in the MRO, which means
-    # that, whenever a `NotFoundLookupError` happens, the method will try itself again,
-    # resulting in an infinite loop. To prevent this from happening, we must adjust the
-    # owner.
-    _owner_transfer[parametric_class] = original_class
+# def is_type(x):
+#     """Check whether `x` is a type or a type hint.
+#     Under the hood, this attempts to construct a :class:`beartype.door.TypeHint` from
+#     `x`. If successful, then `x` is deemed a type or type hint.
+#     Args:
+#         x (object): Object to check.
+#     Returns:
+#         bool: Whether `x` is a type or a type hint.
+#     """
+#     try:
+#         TypeHint(x)
+#         return True
+#     except BeartypeDoorNonpepException:
+#         return False
 
-    # Attempt to correct docstring.
-    try:
-        parametric_class.__doc__ = original_class.__doc__
-    except AttributeError:  # pragma: no cover
-        pass
+# def type_parameter(x):
+#     """Get the type parameter of concrete parametric type or an instance of a concrete
+#     parametric type.
+#     Args:
+#         x (object): Concrete parametric type or instance thereof.
+#     Returns:
+#         object: Type parameter.
+#     """
+#     if is_type(x):
+#         t = x
+#     else:
+#         t = type(x)
+#     if hasattr(t, "parametric"):
+#         return t.type_parameter
+#     raise ValueError(f"`{x}` is not a concrete parametric type or an instance of a"
+#                      f" concrete parametric type.")
 
-    return parametric_class
+# def kind(SuperClass=object):
+#     """Create a parametric wrapper type for dispatch purposes.
+#     Args:
+#         SuperClass (type): Super class.
+#     Returns:
+#         object: New parametric type wrapper.
+#     """
+#     @parametric
+#     class Kind(SuperClass):
+#         def __init__(self, *xs):
+#             self.xs = xs
 
+#         def get(self):
+#             return self.xs[0] if len(self.xs) == 1 else self.xs
 
-def is_concrete(t):
-    """Check if a type `t` is a concrete instance of a parametric type.
-    Args:
-        t (type): Type to check.
-    Returns:
-        bool: `True` if `t` is a concrete instance of a parametric type and `False`
-            otherwise.
-    """
-    return getattr(t, "parametric", False) and t.concrete
+#     return Kind
 
+# Kind = kind()  #: A default kind provided for convenience.
 
-def is_type(x):
-    """Check whether `x` is a type or a type hint.
-    Under the hood, this attempts to construct a :class:`beartype.door.TypeHint` from
-    `x`. If successful, then `x` is deemed a type or type hint.
-    Args:
-        x (object): Object to check.
-    Returns:
-        bool: Whether `x` is a type or a type hint.
-    """
-    try:
-        TypeHint(x)
-        return True
-    except BeartypeDoorNonpepException:
-        return False
+# @parametric
+# class Val:
+#     """A parametric type used to move information from the value domain to the type
+#     domain."""
+#     @classmethod
+#     def __infer_type_parameter__(cls, *arg):
+#         """Function called when the constructor of `Val` is called to determine the type
+#         parameters."""
+#         if len(arg) == 0:
+#             raise ValueError("The value must be specified.")
+#         elif len(arg) > 1:
+#             raise ValueError("Too many values. `Val` accepts only one argument.")
+#         return arg[0]
 
+#     def __init__(self, val=None):
+#         """Construct a value object with type `Val(arg)` that can be used to dispatch
+#         based on values.
+#         Args:
+#             val (object): The value to be moved to the type domain.
+#         """
+#         if type(self).concrete:
+#             if val is not None and type_parameter(self) != val:
+#                 raise ValueError("The value must be equal to the type parameter.")
+#         else:
+#             raise ValueError("The value must be specified.")
 
-def type_parameter(x):
-    """Get the type parameter of concrete parametric type or an instance of a concrete
-    parametric type.
-    Args:
-        x (object): Concrete parametric type or instance thereof.
-    Returns:
-        object: Type parameter.
-    """
-    if is_type(x):
-        t = x
-    else:
-        t = type(x)
-    if hasattr(t, "parametric"):
-        return t.type_parameter
-    raise ValueError(f"`{x}` is not a concrete parametric type or an instance of a"
-                     f" concrete parametric type.")
+#     def __repr__(self):
+#         return repr_short(type(self)) + "()"
 
-
-def kind(SuperClass=object):
-    """Create a parametric wrapper type for dispatch purposes.
-    Args:
-        SuperClass (type): Super class.
-    Returns:
-        object: New parametric type wrapper.
-    """
-    @parametric
-    class Kind(SuperClass):
-        def __init__(self, *xs):
-            self.xs = xs
-
-        def get(self):
-            return self.xs[0] if len(self.xs) == 1 else self.xs
-
-    return Kind
-
-
-Kind = kind()  #: A default kind provided for convenience.
-
-
-@parametric
-class Val:
-    """A parametric type used to move information from the value domain to the type
-    domain."""
-    @classmethod
-    def __infer_type_parameter__(cls, *arg):
-        """Function called when the constructor of `Val` is called to determine the type
-        parameters."""
-        if len(arg) == 0:
-            raise ValueError("The value must be specified.")
-        elif len(arg) > 1:
-            raise ValueError("Too many values. `Val` accepts only one argument.")
-        return arg[0]
-
-    def __init__(self, val=None):
-        """Construct a value object with type `Val(arg)` that can be used to dispatch
-        based on values.
-        Args:
-            val (object): The value to be moved to the type domain.
-        """
-        if type(self).concrete:
-            if val is not None and type_parameter(self) != val:
-                raise ValueError("The value must be equal to the type parameter.")
-        else:
-            raise ValueError("The value must be specified.")
-
-    def __repr__(self):
-        return repr_short(type(self)) + "()"
-
-    def __eq__(self, other):
-        return type(self) is type(other)
+#     def __eq__(self, other):
+#         return type(self) is type(other)

--- a/tests/algorithms/test_arnoldi.py
+++ b/tests/algorithms/test_arnoldi.py
@@ -109,7 +109,7 @@ def test_get_arnoldi_matrix(backend):
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=20, dtype=np.float32) - 0.5
     A = xnp.array(generate_pd_from_diag(diag, dtype=diag.dtype, seed=21), dtype=dtype, device=None)
     rhs = xnp.randn(A.shape[1], 1, dtype=dtype, device=None, key=xnp.PRNGKey(1256))
-    rhs = xnp.concatenate((rhs, rhs), axis=-1)
+    rhs = xnp.concat((rhs, rhs), axis=-1)
     max_iter = A.shape[0]
     A_np, rhs_np = np.array(A, dtype=np.complex128), np.array(rhs[:, 0], dtype=np.complex128)
     Q_sol, H_sol = run_arnoldi(A_np, rhs_np, max_iter=max_iter, tol=1e-7, dtype=np.complex128)

--- a/tests/algorithms/test_arnoldi.py
+++ b/tests/algorithms/test_arnoldi.py
@@ -67,7 +67,7 @@ def test_arnoldi(backend):
     dtype = xnp.complex64
     diag = generate_spectrum(coeff=0.5, scale=1.0, size=4, dtype=np.float32)
     A = xnp.array(generate_lower_from_diag(diag, dtype=diag.dtype, seed=48), dtype=dtype, device=None)
-    zr = xnp.randn(A.shape[1], 1, dtype=xnp.float32, device=None, key=xnp.PRNGKey(123))
+    zr = xnp.randn(A.shape[1], dtype=xnp.float32, device=None, key=xnp.PRNGKey(123))
     rhs = xnp.cast(zr, dtype=dtype)
     eigvals, eigvecs, _ = arnoldi_eigs(lazify(A), rhs, max_iters=A.shape[-1])
     approx = xnp.sort(xnp.cast(eigvals, xnp.float32))
@@ -114,14 +114,16 @@ def test_get_arnoldi_matrix(backend):
     A_np, rhs_np = np.array(A, dtype=np.complex128), np.array(rhs[:, 0], dtype=np.complex128)
     Q_sol, H_sol = run_arnoldi(A_np, rhs_np, max_iter=max_iter, tol=1e-7, dtype=np.complex128)
 
-    fn = xnp.jit(get_arnoldi_matrix, static_argnums=(0, 2, 3, 4))
+    fn = xnp.jit(get_arnoldi_matrix, static_argnums=(2, 3, 4))
     Q_approx, H_approx, *_ = fn(lazify(A), rhs, max_iter, tol=1e-12, pbar=False)
-
-    rel_error = relative_error(Q_approx[:, :, 0], Q_approx[:, :, 1])
-    rel_error += relative_error(H_approx[:, :, 0], H_approx[:, :, 1])
+    todense = xnp.vmap(lambda A: A.to_dense())
+    Q_approx = todense(Q_approx)
+    H_approx = todense(H_approx)
+    rel_error = relative_error(Q_approx[0, :, :], Q_approx[1, :, :])
+    rel_error += relative_error(H_approx[0, :, :], H_approx[1, :, :])
     assert rel_error < 1e-12
 
-    Q_approx, H_approx = Q_approx[:, :, 0], H_approx[:, :, 0]
+    Q_approx, H_approx = Q_approx[0, :, :], H_approx[0, :, :]
     for soln, approx in ((Q_sol[:, :-1], Q_approx), (H_sol[:-1, :], H_approx)):
         rel_error = relative_error(xnp.array(soln, dtype=dtype, device=None), approx)
         assert rel_error < 1e-12

--- a/tests/algorithms/test_gmres.py
+++ b/tests/algorithms/test_gmres.py
@@ -87,11 +87,11 @@ def test_gmres_easy(backend):
 
     approx, _ = fn(lazify(A), rhs, x0, max_iters, tolerance)
     rel_error = relative_error(soln, approx)
-    assert rel_error < 1e-7
+    assert rel_error < 1e-6
 
     approx, _ = fn(lazify(A), rhs, x0, max_iters, tolerance, use_householder=False, use_triangular=True)
     rel_error = relative_error(soln, approx)
-    assert rel_error < 1e-7
+    assert rel_error < 1e-6
 
     # approx, _ = fn(lazify(A), rhs, x0, max_iters, tolerance, use_householder=True,
     #                use_triangular=False)

--- a/tests/algorithms/test_lanczos.py
+++ b/tests/algorithms/test_lanczos.py
@@ -83,7 +83,6 @@ def test_lanczos_complex(backend):
     alpha_np, beta_np, idx_np, Q_np, T_np = case_numpy(A, rhs, xnp, np_dtype)
 
     B = lazify(A)
-    B.xnp = xnp
     max_iters, tol = A.shape[0], 1e-7
     Q, T, info = lanczos(B, rhs, max_iters=max_iters, tol=tol, pbar=False)
     idx = info["iterations"] - 1
@@ -114,7 +113,6 @@ def test_lanczos_random(backend):
     alpha_np, beta_np, idx_np, Q_np, T_np = case_numpy(A, rhs, xnp, np_dtype)
 
     B, max_iters, tol = lazify(A), A.shape[0], 1e-7
-    B.xnp = xnp
     Q, T, info = lanczos(B, rhs, max_iters=max_iters, tol=tol, pbar=False)
     idx = info["iterations"] - 1
     alpha, beta = T.alpha[:, :, 0], T.beta[:, :, 0]
@@ -147,7 +145,6 @@ def test_lanczos_manual(backend):
 
         max_iters, tol = A.shape[0], 1e-7
         B = lazify(A)
-        B.xnp = xnp
         Q, T, info = lanczos(B, rhs, max_iters=max_iters, tol=tol, pbar=False)
         alpha, beta = T.alpha[:, :, 0], T.beta[:, :, 0]
         Q, T = Q.to_dense(), xnp.vmap(T.__class__.to_dense)(T)
@@ -173,7 +170,6 @@ def test_lanczos_iter(backend):
 
     max_iters, tol = A.shape[0], 1e-7
     B = lazify(A)
-    B.xnp = xnp
     Q, T, info = lanczos(B, rhs, max_iters=max_iters, tol=tol, pbar=False)
     idx, Q = info["iterations"] - 1, Q.to_dense()
     alpha, beta = T.alpha[:, :, 0], T.beta[:, :, 0]

--- a/tests/algorithms/test_lanczos.py
+++ b/tests/algorithms/test_lanczos.py
@@ -82,8 +82,10 @@ def test_lanczos_complex(backend):
     rhs = xnp.randn(A.shape[0], 1, dtype=dtype, device=None)
     alpha_np, beta_np, idx_np, Q_np, T_np = case_numpy(A, rhs, xnp, np_dtype)
 
+    B = lazify(A)
+    B.xnp = xnp
     max_iters, tol = A.shape[0], 1e-7
-    Q, T, info = lanczos(lazify(A), rhs, max_iters=max_iters, tol=tol, pbar=False)
+    Q, T, info = lanczos(B, rhs, max_iters=max_iters, tol=tol, pbar=False)
     idx = info["iterations"] - 1
     alpha, beta = T.alpha[:, :, 0], T.beta[:, :, 0]
     Q, T = Q.to_dense(), xnp.vmap(T.__class__.to_dense)(T)
@@ -112,6 +114,7 @@ def test_lanczos_random(backend):
     alpha_np, beta_np, idx_np, Q_np, T_np = case_numpy(A, rhs, xnp, np_dtype)
 
     B, max_iters, tol = lazify(A), A.shape[0], 1e-7
+    B.xnp = xnp
     Q, T, info = lanczos(B, rhs, max_iters=max_iters, tol=tol, pbar=False)
     idx = info["iterations"] - 1
     alpha, beta = T.alpha[:, :, 0], T.beta[:, :, 0]
@@ -143,7 +146,9 @@ def test_lanczos_manual(backend):
         A, rhs, beta_soln, alpha_soln, idx_soln = out
 
         max_iters, tol = A.shape[0], 1e-7
-        Q, T, info = lanczos(lazify(A), rhs, max_iters=max_iters, tol=tol, pbar=False)
+        B = lazify(A)
+        B.xnp = xnp
+        Q, T, info = lanczos(B, rhs, max_iters=max_iters, tol=tol, pbar=False)
         alpha, beta = T.alpha[:, :, 0], T.beta[:, :, 0]
         Q, T = Q.to_dense(), xnp.vmap(T.__class__.to_dense)(T)
         idx = info["iterations"] - 1
@@ -167,7 +172,9 @@ def test_lanczos_iter(backend):
     alpha_np, beta_np, idx_np, Q_np, T_np = case_numpy(A, rhs, xnp)
 
     max_iters, tol = A.shape[0], 1e-7
-    Q, T, info = lanczos(lazify(A), rhs, max_iters=max_iters, tol=tol, pbar=False)
+    B = lazify(A)
+    B.xnp = xnp
+    Q, T, info = lanczos(B, rhs, max_iters=max_iters, tol=tol, pbar=False)
     idx, Q = info["iterations"] - 1, Q.to_dense()
     alpha, beta = T.alpha[:, :, 0], T.beta[:, :, 0]
     T = xnp.vmap(T.__class__.to_dense)(T)

--- a/tests/algorithms/test_lanczos.py
+++ b/tests/algorithms/test_lanczos.py
@@ -147,6 +147,8 @@ def test_lanczos_manual(backend):
         alpha, beta = T.alpha[:, :, 0], T.beta[:, :, 0]
         Q, T = Q.to_dense(), xnp.vmap(T.__class__.to_dense)(T)
         idx = info["iterations"] - 1
+        if backend == "jax":
+            alpha, beta = alpha[:, :idx - 1], beta[:, :idx]
 
         assert idx == idx_soln
         rel_error = relative_error(beta_soln, beta.T)

--- a/tests/algorithms/test_stochastic_lanczos_quad.py
+++ b/tests/algorithms/test_stochastic_lanczos_quad.py
@@ -58,7 +58,6 @@ def test_stochastic_lanczos_quad_random(backend):
     soln = xnp.sum(fun(xnp.array(diag, dtype=dtype, device=None)))
     vtol, max_iters, tol = 1 / np.sqrt(70), A.shape[0], 1e-7
     B = lazify(A)
-    B.xnp = xnp
     approx = stochastic_lanczos_quad(B, fun, max_iters=max_iters, tol=tol, vtol=vtol)
 
     rel_error = relative_error(soln, approx)

--- a/tests/algorithms/test_stochastic_lanczos_quad.py
+++ b/tests/algorithms/test_stochastic_lanczos_quad.py
@@ -57,7 +57,9 @@ def test_stochastic_lanczos_quad_random(backend):
 
     soln = xnp.sum(fun(xnp.array(diag, dtype=dtype, device=None)))
     vtol, max_iters, tol = 1 / np.sqrt(70), A.shape[0], 1e-7
-    approx = stochastic_lanczos_quad(lazify(A), fun, max_iters=max_iters, tol=tol, vtol=vtol)
+    B = lazify(A)
+    B.xnp = xnp
+    approx = stochastic_lanczos_quad(B, fun, max_iters=max_iters, tol=tol, vtol=vtol)
 
     rel_error = relative_error(soln, approx)
     assert rel_error < 1e-1

--- a/tests/linalg/operator_market.py
+++ b/tests/linalg/operator_market.py
@@ -49,46 +49,35 @@ def get_test_operator(backend: str, precision: str, op_name: str, device: str = 
     match op_name.split('_', 1):
         case ('psd', 'diagonal'):
             op = Diagonal(xnp.array([.1, .5, .22, 8.], dtype=dtype, device=device))
-            op.xnp = xnp
 
         case ('psd', ('identity' | 'scalarmul') as sub_op_name):
             shape = (3, 3)
             op = Identity(shape, dtype=dtype)
             if sub_op_name == 'scalarmul':
                 op = 2 * op
-            op.xnp = xnp
 
         case ('psd', ('big' | 'blockdiag' | 'prod') as sub_op_name):
             M1 = Dense(xnp.array([[6., 2], [2, 4]], dtype=dtype, device=device))
             M2 = Dense(xnp.array([[7, 6], [6, 8]], dtype=dtype, device=device))
-            M1.xnp, M2.xnp = xnp, xnp
             match sub_op_name:
                 case 'big':
                     dtype2 = (xnp.array([1.], dtype=dtype, device=device) + 1j).dtype
                     Id = Identity((15, 15), dtype=dtype2)
-                    Id.xnp = xnp
                     big_psd = reduce(cola.kron, [M1, M2, M2, Id])
-                    big_psd.xnp = xnp
                     op = big_psd + 0.04 * cola.ops.I_like(big_psd)
-                    op.xnp = xnp
                 case 'blockdiag':
                     op = BlockDiag(M1, M2, multiplicities=[2, 3])
-                    op.xnp = xnp
                 case 'prod':
                     op = M1 @ M1.T
-                    op.xnp = xnp
         case ('psd', 'kron'):
             M1 = Dense(xnp.array([[0.18, 0.], [0., 0.09]], dtype=dtype, device=device))
             M2 = Dense(xnp.array([[1.2, 0.], [0., 0.7]], dtype=dtype, device=device))
-            M1.xnp, M2.xnp = xnp, xnp
             op = Kronecker(M1, M2)
-            op.xnp = xnp
 
         case ('square', 'complex'):
             U, _, V = xnp.svd(xnp.array([[6. + 1e-1j, 2j], [2, 4j]], dtype=xnp.complex64, device=device))
             d = xnp.array([1, 2. + 0j], dtype=xnp.complex64, device=device)
             op = Dense((d * V) @ xnp.conj(U.T))
-            op.xnp = xnp
 
         case (('selfadj' | 'square') as op_prop, 'tridiagonal'):
             alpha = xnp.array([1, 2, 3], dtype=dtype, device=device)[:2]
@@ -97,10 +86,8 @@ def get_test_operator(backend: str, precision: str, op_name: str, device: str = 
             match op_prop:
                 case 'selfadj':
                     op = Tridiagonal(alpha, beta, alpha)
-                    op.xnp = xnp
                 case 'square':
                     op = Tridiagonal(alpha, beta, gamma)
-                    op.xnp = xnp
 
         case ('selfadj', 'hessian'):
 
@@ -109,7 +96,6 @@ def get_test_operator(backend: str, precision: str, op_name: str, device: str = 
 
             x = xnp.array([1., 2., 3.], dtype=dtype, device=device)
             op = Hessian(f2, x)
-            op.xnp = xnp
 
         case ('square', 'jacobian'):
 
@@ -118,15 +104,12 @@ def get_test_operator(backend: str, precision: str, op_name: str, device: str = 
 
             x = xnp.array([1, 2, 3], dtype=dtype, device=device)
             op = Jacobian(f1, x)
-            op.xnp = xnp
 
         case ('square', 'permutation'):
             op = Permutation(xnp.array([1, 0, 2, 3, 6, 5, 4], dtype=xnp.int32, device=device))
-            op.xnp = xnp
 
         case ('square', 'fft'):
             op = FFT(36, dtype=xnp.complex64).to(device)
-            op.xnp = xnp
         case ('square', sub_op_name):
             M1 = xnp.array([[1, 0], [3, -4]], dtype=dtype, device=device)
             M2 = xnp.array([[-5, 3], [2, -1]], dtype=dtype, device=device)
@@ -140,34 +123,23 @@ def get_test_operator(backend: str, precision: str, op_name: str, device: str = 
                     M2 = [[5, 2, 0], [3., 8, 0], [0, 0, -.5]]
                     M2 = Dense(xnp.array(M2, dtype=dtype2, device=device))
                     Id = Identity((10, 10), dtype=dtype2)
-                    M1.xnp, M2.xnp, Id.xnp = xnp, xnp, xnp
                     big = reduce(cola.kron, [M1, M2, M1 @ M1, M2, Id])
                     op = big + 0.5 * cola.ops.I_like(big)
-                    op.xnp = xnp
                 case 'blockdiag':
                     op = BlockDiag(M1, M2, multiplicities=[2, 3])
-                    op.xnp = xnp
                 case 'dense':
                     op = Dense(M1)
-                    op.xnp = xnp
                 case 'kronecker':
                     M1, M2 = lazify(M1 @ M2), lazify(M2 @ M1)
-                    M1.xnp, M2.xnp = xnp, xnp
                     op = Kronecker(M1, M2)
-                    op.xnp = xnp
                 case 'kronsum':
                     M1, M2 = lazify(M1), lazify(M2)
-                    M1.xnp, M2.xnp = xnp, xnp
                     op = KronSum(M1, M2)
-                    op.xnp = xnp
                 case 'lowertriangular':
                     op = Triangular(M1)
-                    op.xnp = xnp
                 case 'product':
                     M1, M2 = lazify(M1), lazify(M2)
-                    M1.xnp, M2.xnp = xnp, xnp
                     op = Product(M1, M2)
-                    op.xnp = xnp
 
         # case ('square', 'sparse'):
         #     data = xnp.array([1, 2, 3, 4, 5, 6], dtype=dtype, device=device)

--- a/tests/linalg/test_eig.py
+++ b/tests/linalg/test_eig.py
@@ -71,8 +71,6 @@ def test_adjoint(backend):
     assert rel_error < _tol
 
     eig_vals, eig_vecs = eig(A, method="lanczos", max_iters=A.shape[-1])
-    print(eig_vals.shape, eig_vecs.shape)
-    print(soln_vals.shape)
     approx = eig_vecs @ xnp.diag(eig_vals) @ eig_vecs.T
 
     rel_error = relative_error(soln_vals, eig_vals)

--- a/tests/linalg/test_inverse.py
+++ b/tests/linalg/test_inverse.py
@@ -12,11 +12,8 @@ def test_inverse(backend, precision, op_name):
     tol = 1e-5
     A, dtype, xnp = operator, operator.dtype, operator.xnp
     A2 = LinearOperator(A.dtype, A.shape, A._matmat)
-    A2.xnp = operator.xnp
     Ainv = inv(A, tol=tol)
-    Ainv.xnp = operator.xnp
     A3 = cola.PSD(A2) if A.isa(cola.PSD) else A2
-    A3.xnp = operator.xnp
     Ainv2 = inv(A3, tol=tol, method='dense')
     Ainv3 = inv(A3, tol=tol, method='iterative')
     B = xnp.randn(*(A.shape[-1], 10), dtype=dtype, device=None)

--- a/tests/linalg/test_logdet.py
+++ b/tests/linalg/test_logdet.py
@@ -33,7 +33,6 @@ def test_logdet(backend, precision, op_name):
     diag = xnp.diag(Adense)
     assert relative_error(xnp.diag(diag.mean() + 0. * diag), Adense) > 1e-5
     A3 = cola.PSD(A2) if A.isa(cola.PSD) else A2
-    A3.xnp = xnp
     l3 = logdet(A3, tol=tol, method='iterative-stochastic', vtol=3e-2)
     e3 = relative_error(l0, l3)
     assert e3 < 3e-1, f"SLQ logdet failed on {type(A)} with error {e3}"

--- a/tests/linalg/test_unary.py
+++ b/tests/linalg/test_unary.py
@@ -15,7 +15,6 @@ def test_unary(backend, precision, op_name, fn_name):
     spfn = getattr(scipy.linalg, fn_name + 'm')
     A, dtype, xnp = operator, operator.dtype, operator.xnp
     A2 = LinearOperator(A.dtype, A.shape, A._matmat)
-    A2.xnp = xnp
     tol = 1e-4
     v = xnp.randn(A.shape[-1], dtype=dtype, device=None)
     Adense = A.to_dense()
@@ -30,7 +29,6 @@ def test_unary(backend, precision, op_name, fn_name):
     e1 = relative_error(fv, fv1)
     assert e1 < 3 * tol, f"Dispatch rules failed on {type(A)} with error {e1}"
     A3 = cola.SelfAdjoint(A2) if A.isa(cola.SelfAdjoint) else A2
-    A3.xnp = xnp
     if np.prod(A.shape) < 1000:
         fv2 = np.array(fn(A3, tol=tol, method='dense') @ v)
         e2 = relative_error(fv, fv2)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -51,7 +51,6 @@ def test_get_lu_from_tridiagonal(backend):
     beta_j = xnp.array([beta], dtype=dtype, device=None).T
     gamma_j = xnp.array([gamma], dtype=dtype, device=None).T
     B = Tridiagonal(alpha=alpha_j, beta=beta_j, gamma=gamma_j)
-    B.xnp = xnp
     eigenvals = xnp.jit(get_lu_from_tridiagonal, static_argnums=(0, ))(B)
     actual = xnp.array([1 / 4, 4 / 3, 3 / 2, 2], dtype=dtype, device=None)
     sorted_eigenvals = xnp.sort(eigenvals)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -69,9 +69,9 @@ def test_construct_tridiagonal(backend):
     gamma = [0.04, 0.59, 1.1]
     T = [[beta[0], gamma[0], 0, 0], [alpha[0], beta[1], gamma[1], 0], [0., alpha[1], beta[2], gamma[2]],
          [0., 0., alpha[2], beta[3]]]
-    alpha = xnp.array([alpha], dtype=dtype, device=None).T
-    beta = xnp.array([beta], dtype=dtype, device=None).T
-    gamma = xnp.array([gamma], dtype=dtype, device=None).T
+    alpha = xnp.array(alpha, dtype=dtype, device=None)
+    beta = xnp.array(beta, dtype=dtype, device=None)
+    gamma = xnp.array(gamma, dtype=dtype, device=None)
     T_actual = xnp.array(T, dtype=dtype, device=None)
     fn = xnp.jit(construct_tridiagonal)
     T_soln = fn(alpha, beta, gamma)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -2,7 +2,6 @@ import cola as co
 from cola.fns import lazify
 from cola.ops import Tridiagonal
 from cola.algorithms.lanczos import get_lu_from_tridiagonal
-from cola.algorithms.lanczos import construct_tridiagonal
 from cola.linalg.nullspace import nullspace
 from cola.linalg.eigs import power_iteration
 from cola.fns import kron
@@ -58,27 +57,6 @@ def test_get_lu_from_tridiagonal(backend):
     sorted_eigenvals = xnp.sort(eigenvals)
     rel_error = relative_error(actual, sorted_eigenvals)
     assert rel_error < _tol
-
-
-@parametrize(all_backends)
-def test_construct_tridiagonal(backend):
-    xnp = get_xnp(backend)
-    dtype = xnp.float32
-    alpha = [0.73, 1.5, 0.4]
-    beta = [0.8, 0.29, -0.6, 0.9]
-    gamma = [0.04, 0.59, 1.1]
-    T = [[beta[0], gamma[0], 0, 0], [alpha[0], beta[1], gamma[1], 0], [0., alpha[1], beta[2], gamma[2]],
-         [0., 0., alpha[2], beta[3]]]
-    alpha = xnp.array(alpha, dtype=dtype, device=None)
-    beta = xnp.array(beta, dtype=dtype, device=None)
-    gamma = xnp.array(gamma, dtype=dtype, device=None)
-    T_actual = xnp.array(T, dtype=dtype, device=None)
-    fn = xnp.jit(construct_tridiagonal)
-    T_soln = fn(alpha, beta, gamma)
-    rel_error = relative_error(T_actual, T_soln)
-    assert T_actual.shape == T_soln.shape
-    assert rel_error < _tol
-
 
 @parametrize(all_backends)
 def ignore_test_nullspace(backend):

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -58,6 +58,7 @@ def test_get_lu_from_tridiagonal(backend):
     rel_error = relative_error(actual, sorted_eigenvals)
     assert rel_error < _tol
 
+
 @parametrize(all_backends)
 def ignore_test_nullspace(backend):
     xnp = get_xnp(backend)


### PR DESCRIPTION
Refactoring Lanczos and Arnoldi to return LinearOperators as output,
`Q,T,info = lanczos(A,**kwargs)`
where Q,T are linear operators, and likewise for arnoldi.
Removed lanczos_parts and related functions.

Added decorator for parametrize to catch and pass NumpyNotImplemented exceptions for the numpy backend

Refactor to make make logdet, unary, etc jittable and vmappable

see #41 