### PR TITLE
Switching from absolute to relative tolerance for all algorithms

### DIFF
--- a/cola/algorithms/arnoldi.py
+++ b/cola/algorithms/arnoldi.py
@@ -199,10 +199,11 @@ def get_arnoldi_matrix(A: LinearOperator, rhs: Array, max_iters: int, tol: float
     max_iters = min(max_iters, A.shape[0])
 
     def cond_fun(state):
-        *_, idx, norm = state
+        _, H, idx, norm = state
         is_not_max = idx < max_iters
-        is_large = xnp.all(norm >= tol)
-        return is_not_max & is_large
+        is_large = (norm > tol * H[1, 0, :].real) | (idx <= 0)
+        # is_large = norm > tol
+        return is_not_max & xnp.any(is_large)
 
     def body_fun(state):
         Q, H, idx, _ = state

--- a/cola/algorithms/cg.py
+++ b/cola/algorithms/cg.py
@@ -2,7 +2,6 @@ from cola.ops import Array
 from cola.ops import LinearOperator
 from cola.ops import I_like
 from cola.utils.custom_autodiff import iterative_autograd
-# from cola.utils.control_flow import while_loop
 from cola.utils import export
 
 _small_value = 1e-40
@@ -37,21 +36,12 @@ def cg(A: LinearOperator, rhs: Array, x0=None, P=None, tol=1e-6, max_iters=5000,
         x0 = x0[..., None]
     if P is None:
         P = I_like(A)
-    # soln, res, iters, infodict = run_batched_cg(A, rhs, x0, max_iters, tol, P, pbar=pbar)
-    # cg_fn = xnp.jit(run_cg, static_argnums=(0, 3,4,5,6))
-    cg_fn = run_cg
-    # cg_fn = run_batched_cg
-    # TODO: check why the performance degrades so much when adding 5
-    # cg_fn = xnp.jit(run_batched_cg, static_argnums=(0, 5, 6))
-    soln, *_, infodict = cg_fn(A, rhs, x0, max_iters, tol, P, pbar=pbar)
+    soln, *_, infodict = run_cg(A, rhs, x0, max_iters, tol, P, pbar=pbar)
     soln = soln.reshape(-1) if is_vector else soln
-    # infodict['residuals'] = res
-    # infodict['iterations'] = iters
     return soln, infodict
 
 
 def cg_bwd(res, grads, unflatten, *args, **kwargs):
-    # TODO: add static and dynamic
     y_grads = grads[0]
     op_args, output = res
     soln = output[0]
@@ -78,6 +68,9 @@ def run_batched_cg(A, b, x0, max_iters, tol, preconditioner, pbar):
     mult = xnp.norm(b, axis=-2, keepdims=True)
     b_norm = do_safe_div(b, mult, xnp=xnp)
     init_val = initialize(A=A, b=b_norm, preconditioner=preconditioner, x0=x0, xnp=xnp)
+    _, _, r0, *_ = init_val
+    init_tol = tol
+    tol = tol * xnp.norm(r0, axis=-2, keepdims=True)
 
     @xnp.jit
     def cond(state):
@@ -93,9 +86,7 @@ def run_batched_cg(A, b, x0, max_iters, tol, preconditioner, pbar):
     def track_res(state):
         return xnp.norm(state[2], axis=-2).mean()
 
-    while_fn, info = xnp.while_loop_winfo(track_res, tol, max_iters, pbar=pbar)
-    # while_fn, info = while_loop, {}
-    # while_fn, info = xnp.while_loop, {}
+    while_fn, info = xnp.while_loop_winfo(track_res, init_tol, max_iters, pbar=pbar)
     state = while_fn(cond_fun=cond, body_fun=body_fun, init_val=init_val)
     return state[0] * mult, state[2] * mult, state[1], info
 
@@ -157,50 +148,3 @@ def do_safe_div(num, denom, xnp):
     denom = xnp.where(is_zero, _small_value, denom)
     output = num / denom
     return output
-
-
-def run_batched_tracking_cg(A, b, x0, max_iters, tol, preconditioner):
-    xnp = A.xnp
-    mult = xnp.norm(b, axis=-2, keepdims=True)
-    b_norm = do_safe_div(b, mult, xnp=xnp)
-    init_val = initialize_track(A=A, b=b_norm, preconditioner=preconditioner, x0=x0, max_iters=max_iters, xnp=xnp)
-
-    def cond(state):
-        flag = cond_fun_track(state, tol, max_iters, xnp=xnp)
-        return flag
-
-    def body_fun(state):
-        state = take_cg_step_and_track(state, A, preconditioner, xnp=xnp)
-        return state
-
-    while_fn = xnp.while_loop
-    state, tracker = while_fn(cond_fun=cond, body_fun=body_fun, init_val=init_val)
-    return state[0] * mult, state[2] * mult, state[1], tracker
-
-
-def initialize_track(A, b, preconditioner, x0, max_iters, xnp):
-    state = initialize(A=A, b=b, preconditioner=preconditioner, x0=x0, xnp=xnp)
-    *_, gamma0 = state
-    device = A.device
-    alphas = xnp.zeros(shape=(max_iters, ) + gamma0.shape, dtype=b.dtype, device=device)
-    betas = xnp.zeros(shape=(max_iters, ) + gamma0.shape, dtype=b.dtype, device=device)
-    rs = xnp.zeros(shape=(max_iters, ) + gamma0.shape, dtype=b.dtype, device=device)
-    return (state, (rs, alphas, betas))
-
-
-def cond_fun_track(state, tol, max_iters, xnp):
-    value, _ = state
-    return cond_fun(value=value, tol=tol, max_iters=max_iters, xnp=xnp)
-
-
-def take_cg_step_and_track(state_track, A, preconditioner, xnp):
-    state, track = state_track
-    state = take_cg_step(state=state, A=A, preconditioner=preconditioner, xnp=xnp)
-    _, k, r, _, alpha, beta, _ = state
-
-    rs, alphas, betas = track
-    rs = xnp.update_array(rs, xnp.norm(r, axis=-2, keepdims=True), k - 1)
-    alphas = xnp.update_array(alphas, alpha, k - 1)
-    betas = xnp.update_array(betas, beta, k - 1)
-
-    return (state, (rs, alphas, betas))

--- a/cola/algorithms/cg.py
+++ b/cola/algorithms/cg.py
@@ -70,7 +70,7 @@ def run_batched_cg(A, b, x0, max_iters, tol, preconditioner, pbar):
     init_val = initialize(A=A, b=b_norm, preconditioner=preconditioner, x0=x0, xnp=xnp)
     _, _, r0, *_ = init_val
     init_tol = tol
-    tol = tol * xnp.norm(r0, axis=-2, keepdims=True)
+    tol = tol * xnp.norm(r0, axis=-2, keepdims=True) + tol
 
     @xnp.jit
     def cond(state):

--- a/cola/algorithms/lanczos.py
+++ b/cola/algorithms/lanczos.py
@@ -140,15 +140,15 @@ def lanczos(A: LinearOperator, start_vector: Array = None, max_iters=100, tol=1e
 
     def error(state):
         i, *_, alpha = state
-        # rel_err = alpha[..., i - 1].real / xnp.max(alpha[..., 1].real, 1e-30)
-        rel_err = alpha[..., i - 1].real
+        err = xnp.array(1e-30, dtype=alpha.real.dtype, device=xnp.get_device(alpha))
+        rel_err = alpha[..., i - 1].real / xnp.maximum(alpha[..., 1].real, err)
+        # rel_err = alpha[..., i - 1].real
         return xnp.max(rel_err, axis=0) + (i <= 1) * 1.
 
     def cond_fun(state):
         i, *_, alpha = state
         is_max = i <= max_iters
-        # is_tol = (alpha[..., i - 1].real >= tol * alpha[..., 1].real) | (i <= 1)
-        is_tol = (alpha[..., i - 1].real >= tol) | (i <= 1)
+        is_tol = (alpha[..., i - 1].real > tol * alpha[..., 1].real) | (i <= 1)
         flag = is_max & xnp.any(is_tol)
         return flag
 

--- a/cola/algorithms/lanczos.py
+++ b/cola/algorithms/lanczos.py
@@ -147,9 +147,9 @@ def lanczos(A: LinearOperator, start_vector: Array = None, max_iters=100, tol=1e
 
     def cond_fun(state):
         i, *_, alpha = state
-        is_max = i <= max_iters
-        is_tol = (alpha[..., i - 1].real > tol * alpha[..., 1].real) | (i <= 1)
-        flag = is_max & xnp.any(is_tol)
+        is_not_max = i <= max_iters
+        is_large = (alpha[..., i - 1].real > tol * alpha[..., 1].real) | (i <= 1)
+        flag = is_not_max & xnp.any(is_large)
         return flag
 
     init_val = initialize_lanczos_vec(xnp, rhs, max_iters=max_iters, dtype=A.dtype)

--- a/cola/backends/jax_fns.py
+++ b/cola/backends/jax_fns.py
@@ -42,6 +42,7 @@ int64 = jnp.int64
 float32 = jnp.float32
 float64 = jnp.float64
 complex64 = jnp.complex64
+complex128 = jnp.complex128
 long = jnp.int64
 reshape = jnp.reshape
 kron = jnp.kron

--- a/cola/backends/torch_fns.py
+++ b/cola/backends/torch_fns.py
@@ -67,22 +67,6 @@ slogdet = torch.linalg.slogdet
 iscomplexobj = torch.is_complex
 
 
-def softmax(x, axis=-1):
-    return torch.nn.functional.softmax(x, dim=axis)
-
-
-def log_softmax(x, axis=-1):
-    return torch.nn.functional.log_softmax(x, dim=axis)
-
-
-def fft(x, n=None, axis=-1, norm=None):
-    return torch.fft.fft(x, n=n, dim=axis, norm=norm)
-
-
-def ifft(x, n=None, axis=-1, norm=None):
-    return torch.fft.ifft(x, n=n, dim=axis, norm=norm)
-
-
 def get_array_device(array):
     return array.device
 

--- a/tests/algorithms/test_arnoldi.py
+++ b/tests/algorithms/test_arnoldi.py
@@ -102,7 +102,7 @@ def ignore_test_householder_arnoldi_decomp(backend):
         assert rel_error < 1e-5
 
 
-@parametrize(['torch'])  # jax does not have complex128 # yeah it does ?
+@parametrize(['torch'])
 def test_get_arnoldi_matrix(backend):
     xnp = get_xnp(backend)
     dtype = xnp.complex128  # double precision on real and complex coordinates to achieve 1e-12 tol

--- a/tests/algorithms/test_lanczos.py
+++ b/tests/algorithms/test_lanczos.py
@@ -138,7 +138,7 @@ def test_lanczos_random(backend):
 def test_lanczos_manual(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32
-    cases = [case_2, case_3, case_early]
+    cases = [case_early, case_3, case_2]
     for case in cases:
         out = case(xnp, dtype)
         A, rhs, beta_soln, alpha_soln, idx_soln = out


### PR DESCRIPTION
Currently we are using stopping criteria based on absolute tolerances. This is not ideal for really large problems as a really low tolerance might be infeasible to achieve and therefore we are just running the algorithm to the max number of iters each time.

- [X] CG
- [X] Lanczos (affects SLQ)
- [X] Arnoldi (affects GMRES)
