### PR TITLE
Updated pytree backend to address issue #84

### DIFF
--- a/cola/backends/backends.py
+++ b/cola/backends/backends.py
@@ -97,6 +97,6 @@ class AutoRegisteringPyTree(type):
             def tree_unflatten(ctx, children):
                 return cls.tree_unflatten(children, ctx)
 
-            torch.utils._pytree._register_pytree_node(cls, tree_flatten, tree_unflatten)
+            torch.utils._pytree.register_pytree_node(cls, tree_flatten, tree_unflatten)
         except ImportError:
             pass


### PR DESCRIPTION
Updated backends.py to address deprecation warning raised in issue #84 

`...site-packages/cola/backends/backends.py:75: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.`