### PR TITLE
Updated jax_fns to the new device querying

### DIFF
--- a/cola/backends/backends.py
+++ b/cola/backends/backends.py
@@ -45,7 +45,6 @@ def check_valid_dtype(array, dtype, alloc_fn):
         return True
     except TypeError:
         return False
-        # raise TypeError(f"{dtype=} is not valid for {array=}")
 
 
 @export

--- a/cola/backends/backends.py
+++ b/cola/backends/backends.py
@@ -12,10 +12,10 @@ def get_library_fns(dtype):
     try:
         from jax import numpy as jnp
 
-        check_valid_dtype(jnp.array(0.1), dtype=dtype, alloc_fn=lambda x, y: x.astype(y))
-        from cola.backends import jax_fns as fns
+        if check_valid_dtype(jnp.array(0.1), dtype=dtype, alloc_fn=lambda x, y: x.astype(y)):
+            from cola.backends import jax_fns as fns
 
-        return fns
+            return fns
 
     except ImportError:
         pass
@@ -23,16 +23,15 @@ def get_library_fns(dtype):
     try:
         import torch
 
-        check_valid_dtype(torch.tensor(0.1), dtype=dtype, alloc_fn=lambda x, y: x.to(y))
-        from cola.backends import torch_fns as fns
+        if check_valid_dtype(torch.tensor(0.1), dtype=dtype, alloc_fn=lambda x, y: x.to(y)):
+            from cola.backends import torch_fns as fns
 
-        return fns
+            return fns
 
     except ImportError:
         pass
 
-    if dtype in [np.float32, np.float64, np.complex64, np.complex128, np.int32, np.int64]:
-        check_valid_dtype(np.array(0.1), dtype=dtype, alloc_fn=lambda x, y: x.astype(y))
+    if check_valid_dtype(np.array(0.1), dtype=dtype, alloc_fn=lambda x, y: x.astype(y)):
         from cola.backends import np_fns as fns
 
         return fns
@@ -43,8 +42,10 @@ def get_library_fns(dtype):
 def check_valid_dtype(array, dtype, alloc_fn):
     try:
         alloc_fn(array, dtype)
+        return True
     except TypeError:
-        raise TypeError(f"{dtype=} is not a valid for {array=}")
+        return False
+        # raise TypeError(f"{dtype=} is not valid for {array=}")
 
 
 @export

--- a/cola/backends/backends.py
+++ b/cola/backends/backends.py
@@ -1,31 +1,50 @@
-from cola.utils import export
 from types import ModuleType
+
 import numpy as np
+
+from cola.utils import export
 
 
 @export
 def get_library_fns(dtype):
-    """ Given a dtype e.g. jnp.float32 or torch.complex64, returns the appropriate
-        namespace for standard array functionality (either torch_fns or jax_fns)."""
+    """Given a dtype e.g. jnp.float32 or torch.complex64, returns the appropriate
+    namespace for standard array functionality (either torch_fns or jax_fns)."""
     try:
         from jax import numpy as jnp
-        if dtype in [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128, jnp.int32, jnp.int64]:
-            from cola.backends import jax_fns as fns
-            return fns
+
+        check_valid_dtype(jnp.array(0.1), dtype=dtype, alloc_fn=lambda x, y: x.astype(y))
+        from cola.backends import jax_fns as fns
+
+        return fns
+
     except ImportError:
         pass
+
     try:
         import torch
-        if dtype in [torch.float32, torch.float64, torch.complex64, torch.complex128, torch.int32, torch.int64]:
-            from cola.backends import torch_fns as fns
-            return fns
+
+        check_valid_dtype(torch.tensor(0.1), dtype=dtype, alloc_fn=lambda x, y: x.to(y))
+        from cola.backends import torch_fns as fns
+
+        return fns
+
     except ImportError:
         pass
 
     if dtype in [np.float32, np.float64, np.complex64, np.complex128, np.int32, np.int64]:
+        check_valid_dtype(np.array(0.1), dtype=dtype, alloc_fn=lambda x, y: x.astype(y))
         from cola.backends import np_fns as fns
+
         return fns
+
     raise ImportError("No supported array library found")
+
+
+def check_valid_dtype(array, dtype, alloc_fn):
+    try:
+        alloc_fn(array, dtype)
+    except TypeError:
+        raise TypeError(f"{dtype=} is not a valid for {array=}")
 
 
 @export
@@ -34,15 +53,19 @@ def get_xnp(backend: str) -> ModuleType:
         match backend:
             case "torch":
                 from cola.backends import torch_fns as fns
+
                 return fns
             case "jax":
-                from cola.backends import jax_fns as fns
                 import jax
-                jax.config.update('jax_platform_name', 'cpu')  # Force tests to run tests on CPU
+
+                from cola.backends import jax_fns as fns
+
+                jax.config.update("jax_platform_name", "cpu")  # Force tests to run tests on CPU
                 # TODO: do we actually want this here?
                 return fns
             case "numpy":
                 from cola.backends import np_fns as fns
+
                 return fns
             case _:
                 raise ValueError(f"Unknown backend {backend}.")
@@ -56,9 +79,11 @@ class AutoRegisteringPyTree(type):
         super().__init__(*args, **kwargs)
         cls._dynamic = cls._dynamic.copy()
         import optree
-        optree.register_pytree_node_class(cls, namespace='cola')
+
+        optree.register_pytree_node_class(cls, namespace="cola")
         try:
             import jax
+
             jax.tree_util.register_pytree_node_class(cls)
         except ImportError:
             pass

--- a/cola/backends/jax_fns.py
+++ b/cola/backends/jax_fns.py
@@ -1,24 +1,21 @@
-import numpy as np
 import logging
+
 import jax
-from jax import vjp
-from jax import jit, vmap, grad
+import numpy as np
+from jax import grad, jit, vjp, vmap
 from jax import numpy as jnp
 from jax import tree_util as tu
-from jax.random import PRNGKey
-from jax.random import normal
-from jax.lax import while_loop as _while_loop
-from jax.lax import fori_loop as _for_loop
-from jax.lax import conj as conj_lax
-from jax.lax import dynamic_slice
-from jax.lax import expand_dims
-from jax.lax.linalg import cholesky
-from jax.lax.linalg import svd
-from jax.lax.linalg import qr
 from jax.experimental.sparse import CSR
+from jax.lax import conj as conj_lax
+from jax.lax import dynamic_slice, expand_dims
+from jax.lax import fori_loop as _for_loop
+from jax.lax import while_loop as _while_loop
+from jax.lax.linalg import cholesky, qr, svd
+from jax.random import PRNGKey, normal
 from jax.scipy.linalg import block_diag
 from jax.scipy.linalg import lu as lu_lax
 from jax.scipy.linalg import solve_triangular as solvetri
+
 from cola.utils.jax_tqdm import pbar_while, while_loop_winfo
 
 cos = jnp.cos
@@ -115,7 +112,9 @@ def while_loop_no_jit(cond_fun, body_fun, init_val):
 
 
 def get_array_device(array):
-    return list(array.devices())[0]
+    devices = list(array.devices())
+    assert len(devices) == 0, "array found on more than one device"
+    return devices[0]
 
 
 def is_cuda_available():
@@ -169,13 +168,15 @@ def get_device(array):
 
 
 def get_default_device():
-    return jax.devices()[0]
+    devices = list(jax.devices())
+    assert len(devices) == 0, "array found on more than one device"
+    return devices[0]
 
 
 def device(device_name):
     del device_name
     zeros = jnp.zeros(1)
-    return list(zeros.devices())[0]
+    return get_array_device(zeros)
 
 
 def diag(v, diagonal=0):

--- a/cola/backends/jax_fns.py
+++ b/cola/backends/jax_fns.py
@@ -113,7 +113,7 @@ def while_loop_no_jit(cond_fun, body_fun, init_val):
 
 def get_array_device(array):
     devices = list(array.devices())
-    assert len(devices) == 0, "array found on more than one device"
+    assert len(devices) == 1, "array found on more than one device"
     return devices[0]
 
 
@@ -169,7 +169,7 @@ def get_device(array):
 
 def get_default_device():
     devices = list(jax.devices())
-    assert len(devices) == 0, "array found on more than one device"
+    assert len(devices) == 1, "array found on more than one device"
     return devices[0]
 
 

--- a/cola/backends/jax_fns.py
+++ b/cola/backends/jax_fns.py
@@ -115,7 +115,7 @@ def while_loop_no_jit(cond_fun, body_fun, init_val):
 
 
 def get_array_device(array):
-    return array.device()
+    return list(array.devices())[0]
 
 
 def is_cuda_available():
@@ -163,7 +163,7 @@ def lu_solve(a, b):
 
 def get_device(array):
     if not isinstance(array, jax.core.Tracer) and hasattr(array, 'device'):
-        return array.device()
+        return array.device
     else:
         return get_default_device()
 
@@ -175,7 +175,7 @@ def get_default_device():
 def device(device_name):
     del device_name
     zeros = jnp.zeros(1)
-    return zeros.device()
+    return list(zeros.devices())[0]
 
 
 def diag(v, diagonal=0):

--- a/cola/utils/torch_tqdm.py
+++ b/cola/utils/torch_tqdm.py
@@ -72,6 +72,7 @@ def while_loop_winfo(errorfn, tol, max_iters=None, every=1, desc='', pbar=False,
 
 
 def update_pbar(error, tol, info, max_iters):
+    error = float(error)
     errstart = info.setdefault('errstart', error)
     howclose = np.log(error / errstart) / np.log(tol / errstart)
     if max_iters is not None:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'tqdm>=4.38',
         'cola-plum-dispatch==0.1.4',
         'optree',
-        'pytreeclass',
+        # 'pytreeclass',
     ],
     extras_require={
         'dev': ['pytest', 'pytest-cov', 'setuptools_scm', 'pre-commit'],

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+import torch
+from jax import numpy as jnp
+
+from cola.backends.backends import check_valid_dtype
+
+
+def test_check_valid_dtype():
+    def _to(x, y):
+        return x.to(y)
+
+    def _as(x, y):
+        return x.astype(y)
+
+    cases = [
+        (torch.tensor(0.1), torch.Tensor, _to),
+        (np.array(0.1), True, _as),
+        (jnp.array(0.1), True, _as),
+    ]
+    for arr, dty, alloc in cases:
+        with pytest.raises(TypeError):
+            check_valid_dtype(arr, dtype=dty, alloc_fn=alloc)

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import torch
 from jax import numpy as jnp
 
@@ -19,5 +18,4 @@ def test_check_valid_dtype():
         (jnp.array(0.1), True, _as),
     ]
     for arr, dty, alloc in cases:
-        with pytest.raises(TypeError):
-            check_valid_dtype(arr, dtype=dty, alloc_fn=alloc)
+        assert check_valid_dtype(arr, dtype=dty, alloc_fn=alloc) is False

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -1,21 +1,22 @@
 import numpy as np
-import torch
-from jax import numpy as jnp
+import pytest
 
 from cola.backends.backends import check_valid_dtype
 
 
 def test_check_valid_dtype():
-    def _to(x, y):
-        return x.to(y)
+    assert check_valid_dtype(np.array(0.1), dtype=True, alloc_fn=_as) is False
 
-    def _as(x, y):
-        return x.astype(y)
+    torch = pytest.importorskip("torch")
+    assert check_valid_dtype(torch.tensor(0.1), dtype=torch.Tensor, alloc_fn=_to) is False
 
-    cases = [
-        (torch.tensor(0.1), torch.Tensor, _to),
-        (np.array(0.1), True, _as),
-        (jnp.array(0.1), True, _as),
-    ]
-    for arr, dty, alloc in cases:
-        assert check_valid_dtype(arr, dtype=dty, alloc_fn=alloc) is False
+    jnp = pytest.importorskip("jax.numpy")
+    assert check_valid_dtype(jnp.array(0.1), dtype=True, alloc_fn=_as) is False
+
+
+def _to(x, y):
+    return x.to(y)
+
+
+def _as(x, y):
+    return x.astype(y)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,13 +1,11 @@
-from cola.fns import lazify
-from cola.linalg.inverse.inv import inv
-from cola.ops import Tridiagonal
+from cola.backends import all_backends, tracing_backends
+from cola.fns import kron, lazify
 from cola.linalg.decompositions.lanczos import get_lu_from_tridiagonal
-from cola.linalg.tbd.nullspace import nullspace
 from cola.linalg.eig.power_iteration import power_iteration
-from cola.fns import kron
-from cola.utils.test_utils import get_xnp, parametrize, relative_error
-from cola.backends import all_backends
-from cola.utils.test_utils import generate_spectrum, generate_pd_from_diag
+from cola.linalg.inverse.inv import inv
+from cola.linalg.tbd.nullspace import nullspace
+from cola.ops import Tridiagonal
+from cola.utils.test_utils import generate_pd_from_diag, generate_spectrum, get_xnp, parametrize, relative_error
 
 _tol = 1e-7
 
@@ -40,7 +38,7 @@ def test_power_iteration(backend):
     assert rel_error < tol * 100
 
 
-@parametrize(all_backends)
+@parametrize(tracing_backends)
 def test_get_lu_from_tridiagonal(backend):
     xnp = get_xnp(backend)
     dtype = xnp.float32


### PR DESCRIPTION
The latest jax version '0.4.30' changes how a user queries the device of an array. Now we have to use `array.devices()` instead of `array.device()`. Moreover, `array.devices()` outputs a Python set, so I convert it to a list and pass the first element.