### PR TITLE
Corrected device allocation for various Ops (Sum, Product, I_like,...)

### DIFF
--- a/cola/fns.py
+++ b/cola/fns.py
@@ -2,15 +2,28 @@
 Like with linalg, these functions have dispatch rules and should be used in favor of the
 LinearOperator constructors when possible. """
 
-from typing import List, Union, Any
+from typing import Any, List, Union
+
 from plum import dispatch
-from cola.ops import LinearOperator, Array
-from cola.ops import Dense
-from cola.ops import Kronecker, Product, KronSum, Sum
-from cola.ops import ScalarMul, Transpose, Adjoint, Sparse
-from cola.ops import BlockDiag, Diagonal, Triangular, Identity
-from cola.utils import export
+
 import cola
+from cola.ops import (
+    Adjoint,
+    Array,
+    BlockDiag,
+    Dense,
+    Diagonal,
+    Identity,
+    Kronecker,
+    KronSum,
+    LinearOperator,
+    Product,
+    ScalarMul,
+    Sum,
+    Transpose,
+    Triangular,
+)
+from cola.utils import export
 
 Scalar = Array
 
@@ -90,23 +103,24 @@ def add(A: Sum, B: Sum):
 
 @dispatch
 def mul(A: LinearOperator, c: Scalar):
-    S = ScalarMul(c, (A.shape[-2], A.shape[-2]), A.dtype)
+    S = ScalarMul(c, (A.shape[-2], A.shape[-2]), A.dtype, A.device)
     return Product(*[S, A])
 
 
 @dispatch
 def mul(A: ScalarMul, c: Scalar):
-    return ScalarMul(A.c * c, A.shape, A.dtype)
+    return ScalarMul(A.c * c, A.shape, A.dtype, A.device)
 
 
 @dispatch
 def mul(c: Scalar, A: ScalarMul):
-    return ScalarMul(A.c * c, A.shape, A.dtype)
+    return ScalarMul(A.c * c, A.shape, A.dtype, A.device)
 
 
 @dispatch
 def mul(A: ScalarMul, B: ScalarMul):
-    return ScalarMul(A.c * B.c, A.shape, A.dtype)
+    assert A.device == B.device, "there is a device mismatch"
+    return ScalarMul(A.c * B.c, A.shape, A.dtype, A.device)
 
 
 @dispatch

--- a/cola/fns.py
+++ b/cola/fns.py
@@ -19,6 +19,7 @@ from cola.ops import (
     LinearOperator,
     Product,
     ScalarMul,
+    Sparse,
     Sum,
     Transpose,
     Triangular,

--- a/cola/linalg/inverse/inv.py
+++ b/cola/linalg/inverse/inv.py
@@ -1,20 +1,23 @@
 import numpy as np
-from plum import parametric
-from plum import dispatch
-from cola.ops.operators import LinearOperator
-from cola.ops.operators import Diagonal, Permutation
-from cola.ops.operators import Identity
-from cola.ops.operators import ScalarMul
-from cola.ops.operators import BlockDiag, Triangular
-from cola.ops.operators import Kronecker, Product
-from cola.utils import export
+from plum import dispatch, parametric
+
 from cola.annotations import PSD, Unitary
-from cola.linalg.algorithm_base import Algorithm, Auto
-from cola.linalg.decompositions.decompositions import Cholesky, LU
-from cola.linalg.decompositions.decompositions import plu, cholesky
-from cola.linalg.algorithm_base import IterativeOperatorWInfo
+from cola.linalg.algorithm_base import Algorithm, Auto, IterativeOperatorWInfo
+from cola.linalg.decompositions.decompositions import LU, Cholesky, cholesky, plu
 from cola.linalg.inverse.cg import CG
 from cola.linalg.inverse.gmres import GMRES
+from cola.ops.operators import (
+    BlockDiag,
+    Diagonal,
+    Identity,
+    Kronecker,
+    LinearOperator,
+    Permutation,
+    Product,
+    ScalarMul,
+    Triangular,
+)
+from cola.utils import export
 
 
 @export
@@ -114,7 +117,7 @@ def inv(A: Identity, alg: Algorithm):
 
 @dispatch
 def inv(A: ScalarMul, alg: Algorithm):
-    return ScalarMul(1 / A.c, shape=A.shape, dtype=A.dtype)
+    return ScalarMul(1 / A.c, shape=A.shape, dtype=A.dtype, device=A.c.device)
 
 
 @dispatch

--- a/cola/ops/operators.py
+++ b/cola/ops/operators.py
@@ -141,7 +141,7 @@ class Product(LinearOperator):
     def __init__(self, *Ms):
         self.Ms = tuple(cola.fns.lazify(M) for M in Ms)
         devices = [M.device for M in self.Ms]
-        assert all(x == devices[0] for x in devices), "There is a device mismatch"
+        assert all(x == devices[0] for x in devices), "There is a device mismatch in Product"
         for M1, M2 in zip(Ms[:-1], Ms[1:]):
             if M1.shape[-1] != M2.shape[-2]:
                 raise ValueError(f"dimension mismatch {M1.shape} vs {M2.shape}")
@@ -170,7 +170,7 @@ class Sum(LinearOperator):
     def __init__(self, *Ms):
         self.Ms = tuple(cola.fns.lazify(M) for M in Ms)
         devices = [M.device for M in self.Ms]
-        assert all(x == devices[0] for x in devices), "There is a device mismatch"
+        assert all(x == devices[0] for x in devices), "There is a device mismatch in Sum"
         shape = Ms[0].shape
         for M in Ms:
             if M.shape != shape:

--- a/cola/ops/operators.py
+++ b/cola/ops/operators.py
@@ -83,9 +83,10 @@ class Sparse(LinearOperator):
 
 class ScalarMul(LinearOperator):
     """ Linear Operator representing scalar multiplication"""
-    def __init__(self, c, shape, dtype=None):
+    def __init__(self, c, shape, dtype=None, device=None):
         super().__init__(dtype=dtype or type(c), shape=shape)
-        self.c = self.xnp.array(c, dtype=dtype, device=self.device)
+        self.c = self.xnp.array(c, dtype=dtype, device=device)
+        self.device = device
 
     #     self.ensure_const_register_as_array()
 
@@ -128,8 +129,10 @@ class Identity(LinearOperator):
 
 def I_like(A: LinearOperator) -> Identity:
     """ A function that produces an Identity operator with the same
-        shape and dtype as A """
-    return Identity(dtype=A.dtype, shape=A.shape)
+        shape, dtype and device as A """
+    Op = Identity(dtype=A.dtype, shape=A.shape)
+    Op.to(A.device)
+    return Op
 
 
 @parametric
@@ -137,12 +140,15 @@ class Product(LinearOperator):
     """ Matrix Multiply Product of Linear ops """
     def __init__(self, *Ms):
         self.Ms = tuple(cola.fns.lazify(M) for M in Ms)
+        devices = [M.device for M in self.Ms]
+        assert all(x == devices[0] for x in devices), "There is a device mismatch"
         for M1, M2 in zip(Ms[:-1], Ms[1:]):
             if M1.shape[-1] != M2.shape[-2]:
                 raise ValueError(f"dimension mismatch {M1.shape} vs {M2.shape}")
         shape = (Ms[0].shape[-2], Ms[-1].shape[-1])
         dtype = reduce(self.Ms[0].xnp.promote_types, (M.dtype for M in Ms))
         super().__init__(dtype, shape)
+        self.device = devices[0]
 
     def _matmat(self, v):
         for M in self.Ms[::-1]:
@@ -163,12 +169,15 @@ class Sum(LinearOperator):
     """ Sum of Linear ops """
     def __init__(self, *Ms):
         self.Ms = tuple(cola.fns.lazify(M) for M in Ms)
+        devices = [M.device for M in self.Ms]
+        assert all(x == devices[0] for x in devices), "There is a device mismatch"
         shape = Ms[0].shape
         for M in Ms:
             if M.shape != shape:
                 raise ValueError(f"dimension mismatch {M.shape} vs {shape}")
         dtype = Ms[0].dtype
         super().__init__(dtype, shape)
+        self.device = devices[0]
 
     def _matmat(self, v):
         return sum(M @ v for M in self.Ms)
@@ -322,6 +331,7 @@ class Diagonal(LinearOperator):
             >>> op = Diagonal(d)
         """
     def __init__(self, diag):
+        assert len(diag.shape) == 1, f"diagonal is not a vector, it is of shape {diag.shape=}"
         self.diag = diag
         super().__init__(dtype=diag.dtype, shape=(len(diag), ) * 2)
 
@@ -663,5 +673,3 @@ def FIM(logits_fn, theta):
     def entropy(theta):
         log_probs = xnp.log_softmax(logits_fn(theta), axis=-1)
         return -xnp.sum(probs * log_probs, axis=-1).mean()
-
-    return cola.PSD(Hessian(entropy, theta))

--- a/tests/linalg/test_inverse.py
+++ b/tests/linalg/test_inverse.py
@@ -1,16 +1,15 @@
-from scipy.io import mmread
 import pytest
-from cola.linalg.inverse.inv import inv
-from cola.linalg.algorithm_base import Auto
-from cola.ops import LinearOperator
-from cola.ops import Sparse
-from cola.utils.test_utils import get_xnp, parametrize, relative_error
-from cola.utils.test_utils import transform_to_csr
-from cola.linalg.inverse.cg import CG
-from cola.linalg.inverse.gmres import GMRES
+from operator_market import get_test_operator, op_names
+from scipy.io import mmread
+
 from cola.annotations import PSD
 from cola.backends import all_backends, tracing_backends
-from operator_market import op_names, get_test_operator
+from cola.linalg.algorithm_base import Auto
+from cola.linalg.inverse.cg import CG
+from cola.linalg.inverse.gmres import GMRES
+from cola.linalg.inverse.inv import inv
+from cola.ops import LinearOperator, Sparse
+from cola.utils.test_utils import get_xnp, parametrize, relative_error, transform_to_csr
 
 
 @pytest.mark.market

--- a/tests/linalg/test_inverse.py
+++ b/tests/linalg/test_inverse.py
@@ -59,7 +59,7 @@ def test_cg_matrix_market(backend):
         assert rel_error < 1e-7
 
 
-@parametrize(all_backends, ['float64'], op_names).excluding['torch', :, 'psd_kron']
+@parametrize(all_backends, ['float64'], op_names).excluding[:, :, ['psd_kron', 'psd_scalarmul']]
 def test_inverse(backend, precision, op_name):
     operator = get_test_operator(backend, precision, op_name)
     tol = 1e-5

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -56,7 +56,7 @@ def test_device_allocation_through_combination(backend):
     B = Dense(xnp.randn(3, 3, dtype=dtype, device=None))
     B.device = "cuda"
     C = I_like(A)
-    D = C - A @ B
+    D = C + A @ B
     assert D.device == "cuda"
 
 

--- a/tests/test_pytree.py
+++ b/tests/test_pytree.py
@@ -1,10 +1,11 @@
-from cola.fns import kron
-from cola.linalg.logdet.logdet import logdet
-from cola.utils.test_utils import get_xnp, parametrize, relative_error
-from cola.backends import tracing_backends
-from cola.linalg.algorithm_base import Auto
-from cola.ops import Dense, Diagonal, Product, ScalarMul
 from functools import partial
+
+from cola.backends import tracing_backends
+from cola.fns import kron
+from cola.linalg.algorithm_base import Auto
+from cola.linalg.logdet.logdet import logdet
+from cola.ops import Dense, Diagonal, Product, ScalarMul
+from cola.utils.test_utils import get_xnp, parametrize, relative_error
 
 
 @parametrize(tracing_backends).excluding['torch']
@@ -92,7 +93,7 @@ def test_grad(backend):
     g = xnp.grad(f)(D)
     assert relative_error(g.diag, e1) < 1e-6
 
-    g = xnp.grad(f)(Product(D, ScalarMul(3., D.shape, D.dtype)))
+    g = xnp.grad(f)(Product(D, ScalarMul(3., D.shape, D.dtype, device=D.device)))
     g1, g2 = xnp.tree_flatten(g)[0]
     ones = xnp.ones((1, ), dtype=dtype, device=device)
     assert relative_error(g1, 3 * e1) < 1e-6


### PR DESCRIPTION
 Fixed correct device allocation to allow for cola.eig(A - I_like(B))