### PR TITLE
Added "no dispatch" option

### DIFF
--- a/cola/fns.py
+++ b/cola/fns.py
@@ -47,6 +47,12 @@ def densify(A: Union[LinearOperator, Array]):
         return A
 
 
+@export
+def no_dispatch(A: LinearOperator):
+    Op = LinearOperator(dtype=A.dtype, shape=A.shape, matmat=A._matmat)
+    return Op
+
+
 @dispatch
 def dot(A: LinearOperator, B: LinearOperator):
     return Product(A, B)


### PR DESCRIPTION
Now a user can avoid triggering the dispatch rule of an operator that might be comprised of different combinations of other operators.