### PR TITLE
Remove deprecated jax apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![Downloads](https://static.pepy.tech/badge/cola-ml)](https://pepy.tech/project/cola-ml)
 <!-- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/wilson-labs/cola/blob/master/docs/notebooks/colabs/all.ipynb) -->
 
-CoLA is a framework for scalable linear algebra in machine learning and beyond, providing: 
+CoLA is a framework for scalable linear algebra in machine learning and beyond, providing:
 
 (1) Fast hardware-sensitive (GPU accelerated) iterative algorithms for general matrix operations; <br>
 (2) Algorithms that can exploit matrix structure for efficiency; <br>

--- a/cola/linalg/inverse/gmres.py
+++ b/cola/linalg/inverse/gmres.py
@@ -115,7 +115,7 @@ def gmres_fwd(A, rhs, x0, max_iters, tol, P, use_householder, use_triangular, pb
         zero_thresh = 10 * tol * overall_max[:, None]
         padding = xnp.where(largest_vals < zero_thresh, xnp.ones_like(largest_vals), xnp.zeros_like(largest_vals))
         added_diag = xnp.vmap(xnp.diag)(padding)
-        y = xnp.solve(HT @ H + added_diag, HT[..., 0]) * beta[:, None]
+        y = xnp.solve(HT @ H + added_diag, HT[..., 0, None]).squeeze(-1) * beta[:, None]
         zeros = xnp.zeros_like(y)
         y = xnp.where(largest_vals < zero_thresh, zeros, y)
         pred = xnp.permute(Q @ y[..., None], axes=[1, 0, 2])[:, :, 0]

--- a/cola/linalg/tbd/nullspace.py
+++ b/cola/linalg/tbd/nullspace.py
@@ -106,7 +106,7 @@ def krylov_constraint_solve_upto_r(C, r, tol=1e-5, max_iter=10000, pbar=False, i
     if final_error > 5 * tol:
         logging.warning(f"Normalized basis has too high error {final_error:.2e} for tol {tol:.2e}")
     scutoff = (S[rank] if r > rank else 0)
-    text = f"Singular value gap too small: {S[rank-1]:.2e}"
+    text = f"Singular value gap too small: {S[rank - 1]:.2e}"
     text += "above cutoff {scutoff:.2e} below cutoff. Final L, earlier {S[rank-5:rank]}"
     assert rank == 0 or scutoff < S[rank - 1] / 100, text
 

--- a/cola/linalg/unary/unary.py
+++ b/cola/linalg/unary/unary.py
@@ -81,7 +81,7 @@ class ArnoldiUnary(LinearOperator):
         norms = self.xnp.norm(V, axis=0)
 
         e0 = self.xnp.canonical(0, (P.shape[1], V.shape[-1]), dtype=P.dtype, device=self.device)
-        Pinv0 = self.xnp.solve(P, e0.T)  # (bs, m, m) vs (bs, m)
+        Pinv0 = self.xnp.solve(P, e0.T[..., None]).squeeze(-1)  # (bs, m, m) vs (bs, m)
         out = Pinv0 * norms[:, None]  # (bs, m)
         Q = self.xnp.cast(Q, dtype=P.dtype)  # (bs, n, m)
         # (bs,n,m) @ (bs,m,m) @ (bs, m) -> (bs, n)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -32,7 +32,7 @@ def test_power_iteration(backend):
     A = xnp.diag(xnp.array([10., 9.75, 3., 0.1], dtype=dtype, device=None))
     B = lazify(A)
     soln = xnp.array(10., dtype=dtype, device=None)
-    tol, max_iter = 1e-5, 500
+    tol, max_iter = 1e-6, 500
     _, approx, _ = power_iteration(B, tol=tol, max_iter=max_iter, momentum=0.)
     rel_error = relative_error(soln, approx)
     assert rel_error < tol * 100


### PR DESCRIPTION
`jax.experimental.host_callback`  was recently removed in [jax 0.4.35](https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-35-oct-22-2024).

> - `jax.experimental.host_callback` has been deprecated since March 2024, with JAX version 0.4.26. Now we removed it. See https://github.com/jax-ml/jax/issues/20385 for a discussion of alternatives.

This PR replaces `jax.experimental.host_callback`  with `jax.debug.callback` and `jax.experimental.io_callback`. In addition, it implements the batching change in `jax.numpy.linalg.solve()` since [jax 0.5.0](https://jax.readthedocs.io/en/latest/changelog.html#jax-0-5-0-jan-17-2025).

> - [`jax.numpy.linalg.solve()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.linalg.solve.html#jax.numpy.linalg.solve) no longer supports batched 1D arguments on the right hand side. To recover the previous behavior in these cases, use `solve(a, b[..., None]).squeeze(-1)`. 

Lastly, jax's prng changed in 0.5.0 so the generated random numbers will be different.

> Enable jax_threefry_partitionable by default (see [the update note](https://github.com/jax-ml/jax/discussions/18480)).

This is unlucky on the power method test, so I've bumped the relative tolerance slightly.

(Very untested, but at least it passes the tests. It seems tqdm has a bit of a footgun where if a jax array is passed to info, then it'll freeze. Perhaps this should be documented in the `kwargs` argument.)