### PR TITLE
Get JAX default device from config

### DIFF
--- a/cola/backends/jax_fns.py
+++ b/cola/backends/jax_fns.py
@@ -180,9 +180,7 @@ def get_device(array):
 
 
 def get_default_device():
-    devices = list(jax.devices())
-    assert len(devices) == 1, "array found on more than one device"
-    return devices[0]
+    return jax.default_device.value
 
 
 def device(device_name):


### PR DESCRIPTION
Previously, if on a multi-GPU system, `get_default_device()` would always trigger `AssertionError: array found on more than one device"`. 
Instead, the default device should be retrieved from the jax config.